### PR TITLE
squid:S2864 - entrySet() should be iterated when both the key and val…

### DIFF
--- a/src/main/java/org/segrada/controller/FileController.java
+++ b/src/main/java/org/segrada/controller/FileController.java
@@ -312,8 +312,8 @@ public class FileController extends AbstractColoredController<IFile> {
 		if (errors.size() > 0) {
 			try {
 				JSONObject jsonObject = new JSONObject();
-				for (String key : errors.keySet())
-					jsonObject.put(key, errors.get(key));
+				for (Map.Entry<String, String> stringStringEntry : errors.entrySet())
+					jsonObject.put(stringStringEntry.getKey(), stringStringEntry.getValue());
 
 				add = "?errors=" + URLEncoder.encode(jsonObject.toString(), "UTF-8");
 			} catch (Exception e) {

--- a/src/main/java/org/segrada/controller/base/AbstractBaseController.java
+++ b/src/main/java/org/segrada/controller/base/AbstractBaseController.java
@@ -108,20 +108,20 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 			if (o != null && o instanceof Map) { // we have a session object saved - now copy filters
 				Map<String, Object> sessionFilter = (Map<String, Object>) session.getAttribute(key);
 				// copy filter keys that are in sessionFilter, but not in filters
-				for (String filterKey : sessionFilter.keySet()) {
-					if (!filters.containsKey(filterKey))
-						filters.put(filterKey, sessionFilter.get(filterKey));
+				for (Map.Entry<String, Object> stringObjectEntry : sessionFilter.entrySet()) {
+					if (!filters.containsKey(stringObjectEntry.getKey()))
+						filters.put(stringObjectEntry.getKey(), stringObjectEntry.getValue());
 				}
 			}
 		}
 		Map<String, Object> cleanedFilter = new HashMap<>();
-		for (String filterKey : filters.keySet()) {
-			Object o = filters.get(filterKey);
+		for (Map.Entry<String, Object> stringObjectEntry : filters.entrySet()) {
+			Object o = stringObjectEntry.getValue();
 			if (o != null) {
 				if ((o instanceof String && ((String)o).isEmpty()) ||
 						(o instanceof String[] && ((String[])o).length == 0)
 						) continue;
-				cleanedFilter.put(filterKey, o);
+				cleanedFilter.put(stringObjectEntry.getKey(), o);
 			}
 		}
 		// get page and per page settings

--- a/src/main/java/org/segrada/service/repository/orientdb/factory/OrientDbRepositoryFactory.java
+++ b/src/main/java/org/segrada/service/repository/orientdb/factory/OrientDbRepositoryFactory.java
@@ -129,9 +129,9 @@ public class OrientDbRepositoryFactory implements RepositoryFactory {
 			// testing environment
 			if (modelName.startsWith("Mock")) {
 				logger.debug("Working in testing environment: Finding Mock repository.");
-				for (Class repositoryClass : repositoryMap.keySet())
-					if (repositoryClass.getName().contains("Mock"))
-						return (T) repositoryMap.get(repositoryClass);
+				for (Map.Entry<Class, SegradaRepository> classSegradaRepositoryEntry : repositoryMap.entrySet())
+					if (classSegradaRepositoryEntry.getKey().getName().contains("Mock"))
+						return (T) classSegradaRepositoryEntry.getValue();
 			}
 
 			logger.error("Error while producing repository from model name " + modelName, e);

--- a/src/main/java/org/segrada/servlet/SegradaMessageBodyReader.java
+++ b/src/main/java/org/segrada/servlet/SegradaMessageBodyReader.java
@@ -115,17 +115,17 @@ public class SegradaMessageBodyReader implements MessageBodyReader<SegradaEntity
 		}
 
 		// get each form key and value
-		for (String key : parameterMap.keySet()) {
+		for (Map.Entry<String, String[]> stringEntry : parameterMap.entrySet()) {
 			// do not update id, ignore clearTags and _csrf
-			if (key.equals("id") || key.equals("clearTags") || key.equals("_csrf")) continue;
+			if (stringEntry.getKey().equals("id") || stringEntry.getKey().equals("clearTags") || stringEntry.getKey().equals("_csrf")) continue;
 
-			Method setter = setters.get(key);
+			Method setter = setters.get(stringEntry.getKey());
 			if (setter != null) {
 				// get first parameter of setter (type to cast)
 				Class setterType = setter.getParameterTypes()[0];
 
 				// preprocess values
-				String[] values = parameterMap.get(key);
+				String[] values = stringEntry.getValue();
 				// short cut first value - used in most cases
 				String firstValue = values!=null&&values.length>0?values[0]:null;
 				// object representation of value
@@ -133,7 +133,7 @@ public class SegradaMessageBodyReader implements MessageBodyReader<SegradaEntity
 
 				// preprocess values
 				if (value != null && !firstValue.isEmpty()) {
-					if (key.equals("color") && firstValue.startsWith("#")) {
+					if (stringEntry.getKey().equals("color") && firstValue.startsWith("#")) {
 						try {
 							if (value.equals("#ffffffff")) value = null;
 							else value = Integer.decode(firstValue);

--- a/src/main/java/org/segrada/servlet/SegradaSimplePageCachingFilter.java
+++ b/src/main/java/org/segrada/servlet/SegradaSimplePageCachingFilter.java
@@ -133,14 +133,14 @@ public class SegradaSimplePageCachingFilter extends SimplePageCachingFilter {
 			if (controllerData != null && controllerData instanceof Map) {
 				@SuppressWarnings("unchecked")
 				Map<String, Object> d = (Map<String, Object>)controllerData;
-				for (String parameter : d.keySet()) {
-					Object o = d.get(parameter);
+				for (Map.Entry<String, Object> stringObjectEntry : d.entrySet()) {
+					Object o = stringObjectEntry.getValue();
 					String value;
 					// concatenate string array in order to make caching work
 					if (o instanceof String[]) value = String.join(",", (String[]) o);
 					else // all other cases: convert to string
-						value = d.get(parameter).toString();
-					queryData.put(parameter, value);
+						value = stringObjectEntry.getValue().toString();
+					queryData.put(stringObjectEntry.getKey(), value);
 				}
 			}
 		}

--- a/src/main/java/org/segrada/session/ApplicationSettingsProperties.java
+++ b/src/main/java/org/segrada/session/ApplicationSettingsProperties.java
@@ -74,11 +74,11 @@ public class ApplicationSettingsProperties implements ApplicationSettings {
 
 		// now overwrite propeties with those defined as system variables
 		Map<String, String> var = System.getenv();
-		for (String envName : environmentToProperty.keySet()) {
-			if (var.containsKey(envName)) {
+		for (Map.Entry<String, String> stringStringEntry : environmentToProperty.entrySet()) {
+			if (var.containsKey(stringStringEntry.getKey())) {
 				// get value from environment and mapped property name
-				String value = var.get(envName);
-				String key = environmentToProperty.get(envName);
+				String value = var.get(stringStringEntry.getKey());
+				String key = stringStringEntry.getValue();
 				// set property
 				if (value != null) {
 					settings.setProperty(key, value);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat