### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/src/main/java/org/segrada/SegradaLauncher.java
+++ b/src/main/java/org/segrada/SegradaLauncher.java
@@ -206,6 +206,8 @@ public class SegradaLauncher extends JFrame implements ApplicationStatusChangedL
 			case SegradaApplication.STATUS_STOPPED:
 				restartApplication();
 				break;
+			default:
+				break;
 		}
 	}
 
@@ -333,6 +335,8 @@ public class SegradaLauncher extends JFrame implements ApplicationStatusChangedL
 				startStopButton.setEnabled(false);
 				browserButton.setEnabled(false);
 				changeDirectoryButton.setEnabled(false);
+				break;
+			default:
 				break;
 		}
 

--- a/src/main/java/org/segrada/model/File.java
+++ b/src/main/java/org/segrada/model/File.java
@@ -194,6 +194,7 @@ public class File extends AbstractAnnotatedModel implements IFile {
 			case "wav":
 			case "flac":
 				return "audio";
+			default: break;
 		}
 
 		return "";

--- a/src/main/java/org/segrada/model/util/FuzzyFlag.java
+++ b/src/main/java/org/segrada/model/util/FuzzyFlag.java
@@ -42,6 +42,7 @@ public enum FuzzyFlag {
 		switch (flag) {
 			case 'c': return FUZZY_CA;
 			case '?': return FUZZY_UNKNOWN;
+			default: break;
 		}
 		return null;
 	}

--- a/src/main/java/org/segrada/service/util/PaginationInfo.java
+++ b/src/main/java/org/segrada/service/util/PaginationInfo.java
@@ -101,6 +101,7 @@ public class PaginationInfo<BEAN extends SegradaEntity> {
 		switch (total) {
 			case 0: return "paginationNone";
 			case 1: return "paginationOne";
+			default: break;
 		}
 
 		return "pagination";

--- a/src/main/java/org/segrada/util/FuzzyDateRenderer.java
+++ b/src/main/java/org/segrada/util/FuzzyDateRenderer.java
@@ -35,6 +35,7 @@ public class FuzzyDateRenderer {
 				switch (flag) {
 					case 'c': dateString = '~' + dateString; break; // add ca. prefix
 					case '?': dateString += '?'; break; // add ? suffix
+					default: break;
 				}
 
 		if (calendar != null && !calendar.isEmpty() && !calendar.equals("G")) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat