### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/segrada/SegradaApplication.java
+++ b/src/main/java/org/segrada/SegradaApplication.java
@@ -29,7 +29,7 @@ import java.util.*;
  *
  * Segrada application standalone server
  */
-public class SegradaApplication {
+public final class SegradaApplication {
 	private static final Logger logger = LoggerFactory.getLogger(SegradaApplication.class);
 
 	/**
@@ -56,6 +56,10 @@ public class SegradaApplication {
 	 * port to listen to
 	 */
 	private static int port = 8080;
+
+	private SegradaApplication() throws InstantiationException{
+		throw new InstantiationException("The class is not created for instantiation");
+	}
 
 	/**
 	 * prepare context data - get port and contextRoot from environmental variables or properties

--- a/src/main/java/org/segrada/rendering/markup/MarkupFilterFactory.java
+++ b/src/main/java/org/segrada/rendering/markup/MarkupFilterFactory.java
@@ -22,6 +22,10 @@ import java.util.logging.Logger;
 public class MarkupFilterFactory {
 	private static Logger logger = Logger.getLogger(MarkupFilterFactory.class.getName());
 
+	private MarkupFilterFactory() throws InstantiationException{
+		throw new InstantiationException("The class is not created for instantiation");
+	}
+
 	/**
 	 * poduce a markup filter instance or throw exception
 	 * @param type of markup filter, e.g. "default", null will mean default

--- a/src/main/java/org/segrada/rendering/thymeleaf/util/TableSortPreprocessor.java
+++ b/src/main/java/org/segrada/rendering/thymeleaf/util/TableSortPreprocessor.java
@@ -20,7 +20,11 @@ import java.util.Map;
  *
  * Table sorting helper/preprocessor for thymeleaf
  */
-public class TableSortPreprocessor {
+public final class TableSortPreprocessor {
+	private TableSortPreprocessor() throws InstantiationException{
+		throw new InstantiationException("The class is not created for instantiation");
+	}
+
 	/**
 	 * method to create sort link map
 	 * @param baseUrl base url

--- a/src/main/java/org/segrada/util/FuzzyDateRenderer.java
+++ b/src/main/java/org/segrada/util/FuzzyDateRenderer.java
@@ -17,7 +17,11 @@ package org.segrada.util;
  *
  * Fuzzy Date Renderer to print out fuzzy dates nicely
  */
-public class FuzzyDateRenderer {
+public final class FuzzyDateRenderer {
+	private FuzzyDateRenderer() throws InstantiationException{
+		throw new InstantiationException("The class is not created for instantiation");
+	}
+
 	/**
 	 * basic date rendering
 	 * @param julianDate JD value of date

--- a/src/main/java/org/segrada/util/OrientStringEscape.java
+++ b/src/main/java/org/segrada/util/OrientStringEscape.java
@@ -21,7 +21,11 @@ import javax.annotation.Nullable;
  *
  * Simple String escape util inspired by deprecated commons method
  */
-public class OrientStringEscape {
+public final class OrientStringEscape {
+	private OrientStringEscape() throws InstantiationException{
+		throw new InstantiationException("The class is not created for instantiation");
+	}
+
 	/**
 	 * <p>Escapes the characters in a <code>String</code> to be suitable to pass to
 	 * an SQL query.</p>

--- a/src/main/java/org/segrada/util/Preconditions.java
+++ b/src/main/java/org/segrada/util/Preconditions.java
@@ -19,7 +19,11 @@ import javax.annotation.Nullable;
  *
  * Precondition checking - stolen from Guava
  */
-public class Preconditions {
+public final class Preconditions {
+	private Preconditions() throws InstantiationException{
+		throw new InstantiationException("The class is not created for instantiation");
+	}
+
 	/**
 	 * Ensures that an object reference passed as a parameter to the calling method is not null.
 	 *

--- a/src/main/java/org/segrada/util/Sluggify.java
+++ b/src/main/java/org/segrada/util/Sluggify.java
@@ -32,7 +32,7 @@ import static com.google.common.collect.Iterables.transform;
  * Sluggify library - taken from https://github.com/otto-de/sluggify
  * and adapted
  */
-public class Sluggify {
+public final class Sluggify {
 	private static final LoadingCache<String, String> slugifyCache = CacheBuilder.<String,String> newBuilder()
 			.maximumSize(10000)
 			.expireAfterWrite(10, TimeUnit.MINUTES)
@@ -42,6 +42,10 @@ public class Sluggify {
 					return doSlugify(key);
 				}
 			});
+
+	private Sluggify() throws InstantiationException{
+		throw new InstantiationException("The class is not created for instantiation");
+	}
 
 	public static boolean isEmpty(String stringToCheck) {
 		return stringToCheck == null || stringToCheck.isEmpty();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat