### PR TITLE
squid:S00119 - Type parameter names should comply with a naming conve…

### DIFF
--- a/src/main/java/org/segrada/controller/base/AbstractBaseController.java
+++ b/src/main/java/org/segrada/controller/base/AbstractBaseController.java
@@ -2,11 +2,9 @@ package org.segrada.controller.base;
 
 import com.google.inject.Inject;
 import com.sun.jersey.api.view.Viewable;
-import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Ehcache;
 import org.segrada.model.prototype.SegradaEntity;
-import org.segrada.service.ColorService;
 import org.segrada.service.base.AbstractRepositoryService;
 import org.segrada.service.base.SegradaService;
 import org.segrada.service.repository.prototype.CRUDRepository;
@@ -41,7 +39,7 @@ import java.util.Map;
  *
  * Abstract base controller
  */
-abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
+public abstract class AbstractBaseController<T extends SegradaEntity> {
 	@Inject
 	HttpSession session;
 
@@ -51,7 +49,7 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	 * @param <E> type of repository
 	 * @return view with list of entities set
 	 */
-	protected <E extends CRUDRepository<BEAN>> Viewable handleShowAll(AbstractRepositoryService<BEAN, E> service) {
+	protected <E extends CRUDRepository<T>> Viewable handleShowAll(AbstractRepositoryService<T, E> service) {
 		// create model map
 		Map<String, Object> model = new HashMap<>();
 
@@ -68,7 +66,7 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	 * @param filters filter options
 	 * @return view with paginationInfo set
 	 */
-	protected Viewable handlePaginatedIndex(PaginatingRepositoryOrService<BEAN> service, int page, int entriesPerPage, Map<String, Object> filters) {
+	protected Viewable handlePaginatedIndex(PaginatingRepositoryOrService<T> service, int page, int entriesPerPage, Map<String, Object> filters) {
 		return handlePaginatedIndex(service, page, entriesPerPage, filters, null, null);
 	}
 
@@ -82,7 +80,7 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	 * @param model model to fill in (can be null to create new model object)
 	 * @return view with paginationInfo set
 	 */
-	protected Viewable handlePaginatedIndex(PaginatingRepositoryOrService<BEAN> service, int page, int entriesPerPage, Map<String, Object> filters, @Nullable String viewName, @Nullable Map<String, Object> model) {
+	protected Viewable handlePaginatedIndex(PaginatingRepositoryOrService<T> service, int page, int entriesPerPage, Map<String, Object> filters, @Nullable String viewName, @Nullable Map<String, Object> model) {
 		// define default values
 		if (viewName == null) viewName = "index";
 		if (model == null) model = new HashMap<>();
@@ -148,7 +146,7 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	 * @param <E> type of repository
 	 * @return view with detail of entity
 	 */
-	protected <E extends CRUDRepository<BEAN>> Viewable handleShow(String uid, AbstractRepositoryService<BEAN, E> service) {
+	protected <E extends CRUDRepository<T>> Viewable handleShow(String uid, AbstractRepositoryService<T, E> service) {
 		// create model map
 		Map<String, Object> model = new HashMap<>();
 
@@ -183,7 +181,7 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	 * @param <E> type of repository
 	 * @return response, either form view or redirect
 	 */
-	protected <E extends CRUDRepository<BEAN>> Response handleUpdate(BEAN entity, AbstractRepositoryService<BEAN, E> service) {
+	protected <E extends CRUDRepository<T>> Response handleUpdate(T entity, AbstractRepositoryService<T, E> service) {
 		// validate entity
 		Map<String, String> errors = validate(entity);
 		// extra validation
@@ -225,7 +223,7 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	 * @param <E> type of repository
 	 * @return response failed view
 	 */
-	protected <E extends CRUDRepository<BEAN>> Response displayUpdateError(BEAN entity, AbstractRepositoryService<BEAN, E> service) {
+	protected <E extends CRUDRepository<T>> Response displayUpdateError(T entity, AbstractRepositoryService<T, E> service) {
 		return Response.ok(new Viewable("error", "SAVE failed.")).build();
 	}
 
@@ -237,7 +235,7 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	 * @param <E> type of repository
 	 * @return response, either empty response or list
 	 */
-	protected <E extends CRUDRepository<BEAN>> Response handleDelete(String empty, BEAN entity, AbstractRepositoryService<BEAN, E> service) {
+	protected <E extends CRUDRepository<T>> Response handleDelete(String empty, T entity, AbstractRepositoryService<T, E> service) {
 
 		if (!service.delete(entity)) {
 			return Response.ok(new Viewable("error", "DELETE failed.")).build();
@@ -260,24 +258,24 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	}
 
 	/**
-	 * validate bean
+	 * validate T
 	 * @param entity to validate
 	 * @return map containing property and one error message
 	 */
-	protected Map<String, String> validate(BEAN entity) {
+	protected Map<String, String> validate(T entity) {
 		return validate(entity, new HashMap<>());
 	}
 
 	/**
-	 * validate bean
+	 * validate T
 	 * @param entity to validate
 	 * @param errors defined errors already added (may be overwritten)
 	 * @return map containing property and one error message
 	 */
-	protected Map<String, String> validate(BEAN entity, Map<String, String> errors) {
+	protected Map<String, String> validate(T entity, Map<String, String> errors) {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		Validator validator = factory.getValidator();
-		for (ConstraintViolation<BEAN> error : validator.validate(entity)) {
+		for (ConstraintViolation<T> error : validator.validate(entity)) {
 			errors.put(error.getPropertyPath().toString(), error.getMessage());
 		}
 
@@ -294,7 +292,7 @@ abstract public class AbstractBaseController<BEAN extends SegradaEntity> {
 	 * @param errors error map
 	 * @param entity to validate
 	 */
-	protected void validateExtra(Map<String, String> errors, BEAN entity) {
+	protected void validateExtra(Map<String, String> errors, T entity) {
 		//Do nothing by default
 	}
 

--- a/src/main/java/org/segrada/controller/base/AbstractColoredController.java
+++ b/src/main/java/org/segrada/controller/base/AbstractColoredController.java
@@ -23,7 +23,7 @@ import java.util.Map;
  *
  * Abstract colored base controller - injects services for colors and pictograms in controller
  */
-abstract public class AbstractColoredController<BEAN extends SegradaEntity> extends AbstractBaseController<BEAN> {
+public abstract class AbstractColoredController<T extends SegradaEntity> extends AbstractBaseController<T> {
 	@Inject
 	protected ColorService colorService;
 

--- a/src/main/java/org/segrada/service/base/AbstractFullTextService.java
+++ b/src/main/java/org/segrada/service/base/AbstractFullTextService.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  *
  * Abstract service supporting full text search
  */
-abstract public class AbstractFullTextService<BEAN extends SegradaEntity, REPOSITORY extends CRUDRepository<BEAN>> extends AbstractRepositoryService<BEAN, REPOSITORY> {
+abstract public class AbstractFullTextService<T extends SegradaEntity, E extends CRUDRepository<T>> extends AbstractRepositoryService<T, E> {
 	private static final Logger logger = LoggerFactory.getLogger(AbstractFullTextService.class);
 
 	/**
@@ -45,7 +45,7 @@ abstract public class AbstractFullTextService<BEAN extends SegradaEntity, REPOSI
 	}
 
 	@Override
-	public boolean save(BEAN entity) {
+	public boolean save(T entity) {
 		if (super.save(entity)) {
 			indexEntity(entity);
 
@@ -55,7 +55,7 @@ abstract public class AbstractFullTextService<BEAN extends SegradaEntity, REPOSI
 	}
 
 	@Override
-	public boolean delete(BEAN entity) {
+	public boolean delete(T entity) {
 		removeFromSearchIndex(entity);
 		return super.delete(entity);
 	}
@@ -71,7 +71,7 @@ abstract public class AbstractFullTextService<BEAN extends SegradaEntity, REPOSI
 	 * worker to index entity
 	 * @param entity to index
 	 */
-	protected void indexEntity(BEAN entity) {
+	protected void indexEntity(T entity) {
 		SearchIndexEntity searchIndexEntity = prepareIndexEntity(entity);
 		if (searchIndexEntity != null)
 			saveToSearchIndex(searchIndexEntity);
@@ -82,7 +82,7 @@ abstract public class AbstractFullTextService<BEAN extends SegradaEntity, REPOSI
 	 * @param entity to be indexed
 	 * @return SearchIndexEntity or null
 	 */
-	abstract protected @Nullable SearchIndexEntity prepareIndexEntity(BEAN entity);
+	abstract protected @Nullable SearchIndexEntity prepareIndexEntity(T entity);
 
 	/**
 	 * commit converted entity (prepareEntityForSearch) to search index - called by save method
@@ -122,7 +122,7 @@ abstract public class AbstractFullTextService<BEAN extends SegradaEntity, REPOSI
 	 * remove entity from search index
 	 * @param entity to remove from index
 	 */
-	protected void removeFromSearchIndex(@Nullable BEAN entity) {
+	protected void removeFromSearchIndex(@Nullable T entity) {
 		if (entity != null) {
 			searchEngine.remove(entity.getId());
 			if (logger.isInfoEnabled())

--- a/src/main/java/org/segrada/service/base/AbstractRepositoryService.java
+++ b/src/main/java/org/segrada/service/base/AbstractRepositoryService.java
@@ -3,11 +3,8 @@ package org.segrada.service.base;
 import org.segrada.model.prototype.SegradaEntity;
 import org.segrada.service.repository.factory.RepositoryFactory;
 import org.segrada.service.repository.prototype.CRUDRepository;
-import org.segrada.service.repository.prototype.SegradaRepository;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Copyright 2015 Maximilian Kalus [segrada@auxnet.de]
@@ -26,7 +23,7 @@ import java.util.regex.Pattern;
  *
  * Abstract CRUD service
  */
-abstract public class AbstractRepositoryService<BEAN extends SegradaEntity, REPOSITORY extends CRUDRepository<BEAN>> implements SegradaService<BEAN> {
+public abstract class AbstractRepositoryService<T extends SegradaEntity, E extends CRUDRepository<T>> implements SegradaService<T> {
 	/**
 	 * reference to factory
 	 */
@@ -35,7 +32,7 @@ abstract public class AbstractRepositoryService<BEAN extends SegradaEntity, REPO
 	/**
 	 * reference to repository
 	 */
-	protected final REPOSITORY repository;
+	protected final E repository;
 
 	/**
 	 * Constructor
@@ -43,26 +40,26 @@ abstract public class AbstractRepositoryService<BEAN extends SegradaEntity, REPO
 	@SuppressWarnings("unchecked")
 	public AbstractRepositoryService(RepositoryFactory repositoryFactory, Class clazz) {
 		this.repositoryFactory = repositoryFactory;
-		this.repository = (REPOSITORY) repositoryFactory.produceRepository(clazz);
+		this.repository = (E) repositoryFactory.produceRepository(clazz);
 	}
 
 	@Override
-	public BEAN findById(String id) {
+	public T findById(String id) {
 		return repository.find(id);
 	}
 
 	@Override
-	public boolean save(BEAN entity) {
+	public boolean save(T entity) {
 		return repository.save(entity);
 	}
 
 	@Override
-	public boolean delete(BEAN entity) {
+	public boolean delete(T entity) {
 		return repository.delete(entity);
 	}
 
 	@Override
-	public List<BEAN> findAll() {
+	public List<T> findAll() {
 		return repository.findAll();
 	}
 

--- a/src/main/java/org/segrada/service/base/BinaryDataHandler.java
+++ b/src/main/java/org/segrada/service/base/BinaryDataHandler.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
  *
  * Service handling filess
  */
-public interface BinaryDataHandler<BEAN extends SegradaEntity> {
+public interface BinaryDataHandler<T extends SegradaEntity> {
 	/**
 	 * move/map/save binary data of entity to binary data service
 	 *
@@ -29,21 +29,21 @@ public interface BinaryDataHandler<BEAN extends SegradaEntity> {
 	 *
 	 * @param entity containing binary data
 	 */
-	void saveBinaryDataToService(BEAN entity);
+	void saveBinaryDataToService(T entity);
 
 	/**
 	 * delete binary data from service
 	 *
 	 * @param entity containing binary data
 	 */
-	void removeBinaryDataFromService(BEAN entity);
+	void removeBinaryDataFromService(T entity);
 
 	/**
 	 * return data as stream
 	 * @param entity containing binary data
 	 * @return input stream for data
 	 */
-	InputStream getBinaryDataAsStream(BEAN entity);
+	InputStream getBinaryDataAsStream(T entity);
 
 	/**
 	 * return data as stream

--- a/src/main/java/org/segrada/service/base/SearchTermService.java
+++ b/src/main/java/org/segrada/service/base/SearchTermService.java
@@ -21,6 +21,6 @@ import java.util.List;
  *
  * Service implementing a search term method
  */
-public interface SearchTermService<BEAN extends SegradaEntity> {
-	List<BEAN> search(String term);
+public interface SearchTermService<T extends SegradaEntity> {
+	List<T> search(String term);
 }

--- a/src/main/java/org/segrada/service/base/SegradaService.java
+++ b/src/main/java/org/segrada/service/base/SegradaService.java
@@ -21,26 +21,26 @@ import java.util.List;
  *
  * Base service class
  */
-public interface SegradaService<BEAN extends SegradaEntity> {
+public interface SegradaService<T extends SegradaEntity> {
 	/**
-	 * Create a new instance of BEAN
+	 * Create a new instance of T
 	 * @return new instance
 	 */
-	BEAN createNewInstance();
+	T createNewInstance();
 
 	/**
 	 * get class reference of model class
 	 * @return class
 	 */
-	Class<BEAN> getModelClass();
+	Class<T> getModelClass();
 
-	BEAN findById(String id);
+	T findById(String id);
 
-	boolean save(BEAN entity);
+	boolean save(T entity);
 
-	boolean delete(BEAN entity);
+	boolean delete(T entity);
 
-	List<BEAN> findAll();
+	List<T> findAll();
 
 	long count();
 

--- a/src/main/java/org/segrada/service/util/PaginationInfo.java
+++ b/src/main/java/org/segrada/service/util/PaginationInfo.java
@@ -21,7 +21,7 @@ import java.util.List;
  *
  * Class holding pagination information of a certain set
  */
-public class PaginationInfo<BEAN extends SegradaEntity> {
+public class PaginationInfo<T extends SegradaEntity> {
 	/**
 	 * current page to show
 	 */
@@ -45,12 +45,12 @@ public class PaginationInfo<BEAN extends SegradaEntity> {
 	/**
 	 * hits
 	 */
-	public final List<BEAN> entities;
+	public final List<T> entities;
 
 	/**
 	 * constructor
 	 */
-	public PaginationInfo(int page, int pages, int total, int entriesPerPage, List<BEAN> entities) {
+	public PaginationInfo(int page, int pages, int total, int entriesPerPage, List<T> entities) {
 		this.page = page;
 		this.pages = pages;
 		this.total = total;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00119 - Type parameter names should comply with a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S00119

Please let me know if you have any questions.

M-Ezzat