### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/src/main/java/org/segrada/controller/UserController.java
+++ b/src/main/java/org/segrada/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController extends AbstractBaseController<IUser> {
 	private PasswordEncoder passwordEncoder;
 
 	@Inject
-	Identity identity;
+	private Identity identity;
 
 	@Override
 	protected String getBasePath() {

--- a/src/main/java/org/segrada/model/Source.java
+++ b/src/main/java/org/segrada/model/Source.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.Size;
  * Source model implementation
  */
 public class Source extends AbstractAnnotatedModel implements ISource {
-	static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
 	@NotNull(message = "error.notNull")
 	@Size(min=1, message = "error.notEmpty")

--- a/src/main/java/org/segrada/model/SourceReference.java
+++ b/src/main/java/org/segrada/model/SourceReference.java
@@ -25,7 +25,7 @@ import javax.validation.constraints.NotNull;
  * Source reference model implementation
  */
 public class SourceReference extends AbstractSegradaEntity implements ISourceReference {
-	static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
 	@NotNull(message = "error.notNull")
 	private ISource source;

--- a/src/main/java/org/segrada/model/Tag.java
+++ b/src/main/java/org/segrada/model/Tag.java
@@ -27,7 +27,7 @@ import javax.validation.constraints.Size;
  * Tag model implementation
  */
 public class Tag extends AbstractSegradaEntity implements ITag {
-	static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Main title

--- a/src/main/java/org/segrada/servlet/ThymeleafViewProcessor.java
+++ b/src/main/java/org/segrada/servlet/ThymeleafViewProcessor.java
@@ -54,16 +54,16 @@ public class ThymeleafViewProcessor implements ViewProcessor<String> {
 	}
 
 	@Context
-	ServletContext servletContext;
+	private ServletContext servletContext;
 
 	@Context
-	HttpServletRequest servletRequest;
+	private HttpServletRequest servletRequest;
 
 	@Context
-	ThreadLocal<HttpServletRequest> requestInvoker;
+	private ThreadLocal<HttpServletRequest> requestInvoker;
 
 	@Context
-	ThreadLocal<HttpServletResponse> responseInvoker;
+	private ThreadLocal<HttpServletResponse> responseInvoker;
 
 	private TemplateEngine templateEngine;
 

--- a/src/main/java/org/segrada/session/CSRFTokenManager.java
+++ b/src/main/java/org/segrada/session/CSRFTokenManager.java
@@ -17,7 +17,7 @@ final public class CSRFTokenManager {
 	/**
 	 * The token parameter name
 	 */
-	static final String CSRF_PARAM_NAME = "_csrf";
+	private static final String CSRF_PARAM_NAME = "_csrf";
 
 	/**
 	 * The location on the session which stores the token

--- a/src/main/java/org/segrada/session/Identity.java
+++ b/src/main/java/org/segrada/session/Identity.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 @SessionScoped
 public class Identity implements Serializable {
-	static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * reference to user


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat