### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/main/java/org/segrada/controller/PageController.java
+++ b/src/main/java/org/segrada/controller/PageController.java
@@ -157,7 +157,7 @@ public class PageController {
 		// read lines
 		try {
 			String line;
-			BufferedReader in = new BufferedReader(new InputStreamReader(is));
+			BufferedReader in = new BufferedReader(new InputStreamReader(is, "UTF-8"));
 
 			while((line = in.readLine()) != null) {
 				sb.append(line).append('\n');

--- a/src/main/java/org/segrada/service/binarydata/BinaryDataServiceFile.java
+++ b/src/main/java/org/segrada/service/binarydata/BinaryDataServiceFile.java
@@ -8,7 +8,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileInputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 import static org.segrada.util.Preconditions.checkNotNull;
 
@@ -96,9 +105,11 @@ public class BinaryDataServiceFile extends AbstractBinaryDataBaseService {
 
 			// write metadata to file
 			File metadata = new File(myFile.getAbsolutePath() + ".metadata");
-			FileWriter fileWriter = new FileWriter(metadata);
-			fileWriter.write(fileName + "\n" + entity.getModelName() + ":" + entity.getId() + "\n" + mimeType);
-			fileWriter.close();
+			FileOutputStream fileOutputStream = new FileOutputStream(metadata);
+			OutputStreamWriter outputStreamWriter = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
+
+			outputStreamWriter.write(fileName + "\n" + entity.getModelName() + ":" + entity.getId() + "\n" + mimeType);
+			outputStreamWriter.close();
 
 			String newFileReference = myFile.getName();
 
@@ -124,16 +135,19 @@ public class BinaryDataServiceFile extends AbstractBinaryDataBaseService {
 			File metadata = new File(new File(savePath, id) + ".metadata");
 
 			// read metadata
-			BufferedReader fileReader = new BufferedReader(new FileReader(metadata));
+			FileInputStream fileInputStream = new FileInputStream(metadata);
+			InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, StandardCharsets.UTF_8);
+			BufferedReader fileReader = new BufferedReader(inputStreamReader);
 			String fileName = fileReader.readLine().trim();
 			String oldReference = fileReader.readLine().trim();
 			String mimeType = fileReader.readLine().trim();
 			fileReader.close();
 
 			// read first line from metadata
-			FileWriter fileWriter = new FileWriter(metadata);
-			fileWriter.write(fileName + "\n" + entity.getModelName() + ":" + entity.getId() + "\n" + mimeType);
-			fileWriter.close();
+			FileOutputStream fileOutputStream = new FileOutputStream(metadata);
+			OutputStreamWriter outputStreamWriter = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8);
+			outputStreamWriter.write(fileName + "\n" + entity.getModelName() + ":" + entity.getId() + "\n" + mimeType);
+			outputStreamWriter.close();
 
 			if (logger.isInfoEnabled())
 				logger.info("Updated reference id from " + oldReference + " to " + entity.getModelName());
@@ -171,7 +185,9 @@ public class BinaryDataServiceFile extends AbstractBinaryDataBaseService {
 			// read first line from metadata
 			File metadata = new File(new File(savePath, id) + ".metadata");
 
-			BufferedReader fileReader = new BufferedReader(new FileReader(metadata));
+			FileInputStream fileInputStream = new FileInputStream(metadata);
+			InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, StandardCharsets.UTF_8);
+			BufferedReader fileReader = new BufferedReader(inputStreamReader);
 			String fileName = fileReader.readLine().trim();
 			fileReader.close();
 

--- a/src/main/java/org/segrada/service/binarydata/BinaryDataServiceHadoop.java
+++ b/src/main/java/org/segrada/service/binarydata/BinaryDataServiceHadoop.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Copyright 2015 Maximilian Kalus [segrada@auxnet.de]
@@ -151,7 +152,7 @@ public class BinaryDataServiceHadoop extends AbstractBinaryDataBaseService {
 
 			// write meta data file
 			String metaData = myFile + ".metadata";
-			byte[] metaDataContent = (fileName + "\n" + entity.getModelName() + ":" + entity.getId() + "\n" + mimeType).getBytes();
+			byte[] metaDataContent = (fileName + "\n" + entity.getModelName() + ":" + entity.getId() + "\n" + mimeType).getBytes(StandardCharsets.UTF_8);
 
 			out = client.create(metaData, true);
 			in = new BufferedInputStream(new ByteArrayInputStream(metaDataContent));

--- a/src/main/java/org/segrada/service/repository/orientdb/init/OrientDbSchemaUpdater.java
+++ b/src/main/java/org/segrada/service/repository/orientdb/init/OrientDbSchemaUpdater.java
@@ -17,6 +17,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -197,7 +198,7 @@ public class OrientDbSchemaUpdater {
 		// read sql lines and update
 		try {
 			String line;
-			BufferedReader in = new BufferedReader(new InputStreamReader(is));
+			BufferedReader in = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 
 			while((line = in.readLine()) != null) {
 				if (!line.equals("") && !line.startsWith("#"))

--- a/src/main/java/org/segrada/servlet/SegradaUpdateChecker.java
+++ b/src/main/java/org/segrada/servlet/SegradaUpdateChecker.java
@@ -14,6 +14,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -156,7 +157,7 @@ public class SegradaUpdateChecker {
 			// relatively short timeouts
 			conn.setConnectTimeout(5000);
 			conn.setReadTimeout(5000);
-			BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+			BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
 			String line;
 			while ((line = rd.readLine()) != null) {
 				result.append(line);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat