### PR TITLE
Migrate to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,9 +319,9 @@
 
 		<!-- Testing -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.9.1</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -347,6 +347,11 @@
 					</compilerArguments>
 				</configuration>
 			</plugin>
+			<!-- unit tests -->
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+			</plugin>
 			<!-- create JAR and dependencies -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -364,7 +369,7 @@
 							<overWriteReleases>false</overWriteReleases>
 							<overWriteSnapshots>false</overWriteSnapshots>
 							<overWriteIfNewer>true</overWriteIfNewer>
-							<excludeArtifactIds>junit</excludeArtifactIds>
+							<excludeArtifactIds>junit-jupiter</excludeArtifactIds>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/test/java/org/segrada/model/ColorTest.java
+++ b/src/test/java/org/segrada/model/ColorTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,13 +9,13 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class ColorTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -32,28 +32,28 @@ public class ColorTest {
 		color.setTitle("Example title");
 		color.setColor(123456);
 		Set<ConstraintViolation<Color>> constraintViolations = validator.validate(color);
-		assertTrue("Color not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Color not valid");
 	}
 
 	@Test
 	public void testTitleEmpty() throws Exception {
 		Set<ConstraintViolation<Color>> constraintViolations = validator.validateValue(Color.class, "title", null);
-		assertTrue("Title empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title empty");
 	}
 
 	@Test
 	public void testTitleTooShort() throws Exception {
 		Set<ConstraintViolation<Color>> constraintViolations = validator.validateValue(Color.class, "title", "");
-		assertTrue("Title too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title too short");
 	}
 
 	@Test
 	public void testColorEmpty() throws Exception {
 		Set<ConstraintViolation<Color>> constraintViolations = validator.validateValue(Color.class, "color", null);
-		assertTrue("Color empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Color empty");
 
 		constraintViolations = validator.validateValue(Color.class, "color", 0);
-		assertTrue("Color can be 0!", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Color can be 0!");
 	}
 
 	@Test

--- a/src/test/java/org/segrada/model/CommentTest.java
+++ b/src/test/java/org/segrada/model/CommentTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,13 +9,13 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class CommentTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -32,24 +32,24 @@ public class CommentTest {
 		comment.setText("Example text");
 		comment.setMarkup("DUMMY");
 		Set<ConstraintViolation<Comment>> constraintViolations = validator.validate(comment);
-		assertTrue("Comment not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Comment not valid");
 	}
 
 	@Test
 	public void testTextEmpty() throws Exception {
 		Set<ConstraintViolation<Comment>> constraintViolations = validator.validateValue(Comment.class, "text", null);
-		assertTrue("Text empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Text empty");
 	}
 
 	@Test
 	public void testTextTooShort() throws Exception {
 		Set<ConstraintViolation<Comment>> constraintViolations = validator.validateValue(Comment.class, "text", "");
-		assertTrue("Text too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Text too short");
 	}
 
 	@Test
 	public void testmarkupEmpty() throws Exception {
 		Set<ConstraintViolation<Comment>> constraintViolations = validator.validateValue(Comment.class, "markup", null);
-		assertTrue("Markup empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Markup empty");
 	}
 }

--- a/src/test/java/org/segrada/model/FileTest.java
+++ b/src/test/java/org/segrada/model/FileTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,7 +9,7 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class FileTest {
@@ -17,7 +17,7 @@ public class FileTest {
 
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -52,49 +52,49 @@ public class FileTest {
 		file.setData(fileData);
 		file.setDescriptionMarkup("default");
 		Set<ConstraintViolation<File>> constraintViolations = validator.validate(file);
-		assertTrue("File not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "File not valid");
 	}
 
 	@Test
 	public void testFilenameEmpty() throws Exception {
 		Set<ConstraintViolation<File>> constraintViolations = validator.validateValue(File.class, "filename", null);
-		assertTrue("Filename empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Filename empty");
 	}
 
 	@Test
 	public void testFilenameTooShort() throws Exception {
 		Set<ConstraintViolation<File>> constraintViolations = validator.validateValue(File.class, "filename", "");
-		assertTrue("Filename too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Filename too short");
 	}
 
 	@Test
 	public void testMimeTypeEmpty() throws Exception {
 		Set<ConstraintViolation<File>> constraintViolations = validator.validateValue(File.class, "mimeType", null);
-		assertTrue("MimeType empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "MimeType empty");
 	}
 
 	@Test
 	public void testMimeTypeTooShort() throws Exception {
 		Set<ConstraintViolation<File>> constraintViolations = validator.validateValue(File.class, "mimeType", "");
-		assertTrue("MimeType too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "MimeType too short");
 	}
 
 	@Test
 	public void testIndexFullTextEmpty() throws Exception {
 		Set<ConstraintViolation<File>> constraintViolations = validator.validateValue(File.class, "indexFullText", null);
-		assertTrue("indexFullText empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "indexFullText empty");
 	}
 
 	@Test
 	public void testContainFileEmpty() throws Exception {
 		Set<ConstraintViolation<File>> constraintViolations = validator.validateValue(File.class, "containFile", null);
-		assertTrue("containFile empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "containFile empty");
 	}
 
 	@Test
 	public void testDescriptionMarkupEmpty() throws Exception {
 		Set<ConstraintViolation<File>> constraintViolations = validator.validateValue(File.class, "descriptionMarkup", null);
-		assertTrue("Description markup empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Description markup empty");
 	}
 
 	@Test

--- a/src/test/java/org/segrada/model/LocationTest.java
+++ b/src/test/java/org/segrada/model/LocationTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,13 +9,13 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class LocationTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -35,51 +35,51 @@ public class LocationTest {
 		location.setLongitude(21.0);
 		location.setComment(null);
 		Set<ConstraintViolation<Location>> constraintViolations = validator.validate(location);
-		assertTrue("Location not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Location not valid");
 	}
 
 	@Test
 	public void testParentEmpty() throws Exception {
 		Set<ConstraintViolation<Location>> constraintViolations = validator.validateValue(Location.class, "parentId", null);
-		assertTrue("Parent Id empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Parent Id empty");
 
 		constraintViolations = validator.validateValue(Location.class, "parentModel", null);
-		assertTrue("Parent model empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Parent model empty");
 	}
 
 	@Test
 	public void testLatitudeEmpty() throws Exception {
 		Set<ConstraintViolation<Location>> constraintViolations = validator.validateValue(Location.class, "latitude", null);
-		assertTrue("Latitude empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Latitude empty");
 	}
 
 	@Test
 	public void testLatitudeTooLow() throws Exception {
 		Set<ConstraintViolation<Location>> constraintViolations = validator.validateValue(Location.class, "latitude", -500);
-		assertTrue("Latitude too low", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Latitude too low");
 	}
 
 	@Test
 	public void testLatitudeTooHigh() throws Exception {
 		Set<ConstraintViolation<Location>> constraintViolations = validator.validateValue(Location.class, "latitude", 500);
-		assertTrue("Latitude too high", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Latitude too high");
 	}
 
 	@Test
 	public void testLongitudeEmpty() throws Exception {
 		Set<ConstraintViolation<Location>> constraintViolations = validator.validateValue(Location.class, "longitude", null);
-		assertTrue("Longitude empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Longitude empty");
 	}
 
 	@Test
 	public void testLongitudeTooLow() throws Exception {
 		Set<ConstraintViolation<Location>> constraintViolations = validator.validateValue(Location.class, "longitude", -500);
-		assertTrue("Longitude too low", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Longitude too low");
 	}
 
 	@Test
 	public void testLongitudeTooHigh() throws Exception {
 		Set<ConstraintViolation<Location>> constraintViolations = validator.validateValue(Location.class, "longitude", 500);
-		assertTrue("Longitude too high", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Longitude too high");
 	}
 }

--- a/src/test/java/org/segrada/model/NodeTest.java
+++ b/src/test/java/org/segrada/model/NodeTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,15 +9,15 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class NodeTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -45,31 +45,31 @@ public class NodeTest {
 		node.setAlternativeTitles("");
 		node.setDescription("Description");
 		Set<ConstraintViolation<Node>> constraintViolations = validator.validate(node);
-		assertTrue("Node not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Node not valid");
 	}
 
 	@Test
 	public void testTitleEmpty() throws Exception {
 		Set<ConstraintViolation<Node>> constraintViolations = validator.validateValue(Node.class, "title", null);
-		assertTrue("Title empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title empty");
 	}
 
 	@Test
 	public void testTitleTooShort() throws Exception {
 		Set<ConstraintViolation<Node>> constraintViolations = validator.validateValue(Node.class, "title", "");
-		assertTrue("Title too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title too short");
 	}
 
 	@Test
 	public void testAlternativeTitlesEmpty() throws Exception {
 		Set<ConstraintViolation<Node>> constraintViolations = validator.validateValue(Node.class, "alternativeTitles", null);
-		assertTrue("Alternative titles empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Alternative titles empty");
 	}
 
 	@Test
 	public void testDescriptionEmpty() throws Exception {
 		Set<ConstraintViolation<Node>> constraintViolations = validator.validateValue(Node.class, "description", null);
-		assertTrue("Description empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Description empty");
 	}
 
 	/*@Test can be "" for now
@@ -81,6 +81,6 @@ public class NodeTest {
 	@Test
 	public void testDescriptionMarkupEmpty() throws Exception {
 		Set<ConstraintViolation<Node>> constraintViolations = validator.validateValue(Node.class, "descriptionMarkup", null);
-		assertTrue("Description markup empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Description markup empty");
 	}
 }

--- a/src/test/java/org/segrada/model/PeriodTest.java
+++ b/src/test/java/org/segrada/model/PeriodTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,13 +9,13 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class PeriodTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -34,7 +34,7 @@ public class PeriodTest {
 		period.setFromEntry("21.05.2000");
 		period.setToEntry("22.05.2009");
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validate(period);
-		assertTrue("Period not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Period not valid");
 
 		assertEquals("period", period.getType());
 		assertEquals(new Long(2451686L), period.getFromJD());
@@ -50,7 +50,7 @@ public class PeriodTest {
 		period.setFromEntry("21.05.2009");
 		period.setToEntry("22.05.2000");
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validate(period);
-		assertTrue("Invalid Period is valid", constraintViolations.size() > 0);
+		assertTrue(constraintViolations.size() > 0, "Invalid Period is valid");
 	}
 
 	@Test
@@ -62,12 +62,12 @@ public class PeriodTest {
 		period.setFromEntry("");
 		period.setToEntry("");
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validate(period);
-		assertTrue("Invalid Period is valid", constraintViolations.size() > 0);
+		assertTrue(constraintViolations.size() > 0, "Invalid Period is valid");
 
 		period.setFromEntry(null);
 		period.setToEntry(null);
 		constraintViolations = validator.validate(period);
-		assertTrue("Invalid Period is valid", constraintViolations.size() > 0);
+		assertTrue(constraintViolations.size() > 0, "Invalid Period is valid");
 	}
 
 	@Test
@@ -134,58 +134,58 @@ public class PeriodTest {
 	@Test
 	public void testParentEmpty() throws Exception {
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validateValue(Period.class, "parentId", null);
-		assertTrue("Parent Id empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Parent Id empty");
 
 		constraintViolations = validator.validateValue(Period.class, "parentModel", null);
-		assertTrue("Parent model empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Parent model empty");
 	}
 
 	@Test
 	public void testFromEmpty() throws Exception {
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validateValue(Period.class, "fromJD", null);
-		assertTrue("from empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "from empty");
 	}
 
 	@Test
 	public void testToEmpty() throws Exception {
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validateValue(Period.class, "toJD", null);
-		assertTrue("to empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "to empty");
 	}
 
 	@Test
 	public void testFromEntryCalendarEmpty() throws Exception {
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validateValue(Period.class, "fromEntryCalendar", null);
-		assertTrue("fromEntryCalendar empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "fromEntryCalendar empty");
 	}
 
 	@Test
 	public void testToEntryCalendarEmpty() throws Exception {
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validateValue(Period.class, "toEntryCalendar", null);
-		assertTrue("toEntryCalendar empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "toEntryCalendar empty");
 	}
 
 	@Test
 	public void testFromEntryCalendarValidSettings() throws Exception {
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validateValue(Period.class, "fromEntryCalendar", "G");
-		assertTrue("fromEntryCalendar settings", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "fromEntryCalendar settings");
 
 		constraintViolations = validator.validateValue(Period.class, "fromEntryCalendar", "J");
-		assertTrue("fromEntryCalendar settings", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "fromEntryCalendar settings");
 
 		constraintViolations = validator.validateValue(Period.class, "fromEntryCalendar", "");
-		assertTrue("fromEntryCalendar settings", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "fromEntryCalendar settings");
 	}
 
 	@Test
 	public void testToEntryCalendarValidSettings() throws Exception {
 		Set<ConstraintViolation<Period>> constraintViolations = validator.validateValue(Period.class, "toEntryCalendar", "G");
-		assertTrue("toEntryCalendar settings", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "toEntryCalendar settings");
 
 		constraintViolations = validator.validateValue(Period.class, "toEntryCalendar", "J");
-		assertTrue("toEntryCalendar settings", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "toEntryCalendar settings");
 
 		constraintViolations = validator.validateValue(Period.class, "toEntryCalendar", "");
-		assertTrue("toEntryCalendar settings", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "toEntryCalendar settings");
 	}
 
 	@Test

--- a/src/test/java/org/segrada/model/PictogramTest.java
+++ b/src/test/java/org/segrada/model/PictogramTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,8 +9,8 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class PictogramTest {
@@ -18,7 +18,7 @@ public class PictogramTest {
 
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -42,18 +42,18 @@ public class PictogramTest {
 		pictogram.setTitle("Example Titel");
 		pictogram.setData(pictureData);
 		Set<ConstraintViolation<Pictogram>> constraintViolations = validator.validate(pictogram);
-		assertTrue("Pictogram not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Pictogram not valid");
 	}
 
 	@Test
 	public void testTitleEmpty() throws Exception {
 		Set<ConstraintViolation<Pictogram>> constraintViolations = validator.validateValue(Pictogram.class, "title", null);
-		assertTrue("Title empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title empty");
 	}
 
 	@Test
 	public void testTitleTooShort() throws Exception {
 		Set<ConstraintViolation<Pictogram>> constraintViolations = validator.validateValue(Pictogram.class, "title", "T");
-		assertTrue("Title too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title too short");
 	}
 }

--- a/src/test/java/org/segrada/model/RelationTest.java
+++ b/src/test/java/org/segrada/model/RelationTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.prototype.INode;
 import org.segrada.model.prototype.IRelation;
 import org.segrada.model.prototype.IRelationType;
@@ -12,13 +12,13 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class RelationTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -48,31 +48,31 @@ public class RelationTest {
 		relation.setFromEntity(fromNode);
 		relation.setToEntity(toNode);
 		Set<ConstraintViolation<Relation>> constraintViolations = validator.validate(relation);
-		assertTrue("Relation not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Relation not valid");
 	}
 
 	@Test
 	public void testRelationTypeEmpty() throws Exception {
 		Set<ConstraintViolation<Relation>> constraintViolations = validator.validateValue(Relation.class, "relationType", null);
-		assertTrue("RelationType empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "RelationType empty");
 	}
 
 	@Test
 	public void testFromEntityEmpty() throws Exception {
 		Set<ConstraintViolation<Relation>> constraintViolations = validator.validateValue(Relation.class, "fromEntity", null);
-		assertTrue("FromEntity empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "FromEntity empty");
 	}
 
 	@Test
 	public void testToEntityEmpty() throws Exception {
 		Set<ConstraintViolation<Relation>> constraintViolations = validator.validateValue(Relation.class, "toEntity", null);
-		assertTrue("ToEntity empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "ToEntity empty");
 	}
 
 	@Test
 	public void testDescriptionEmpty() throws Exception {
 		Set<ConstraintViolation<Relation>> constraintViolations = validator.validateValue(Relation.class, "description", null);
-		assertTrue("Description empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Description empty");
 	}
 
 	/*@Test can be "" for now
@@ -84,7 +84,7 @@ public class RelationTest {
 	@Test
 	public void testDescriptionMarkupEmpty() throws Exception {
 		Set<ConstraintViolation<Relation>> constraintViolations = validator.validateValue(Relation.class, "descriptionMarkup", null);
-		assertTrue("Description markup empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Description markup empty");
 	}
 
 	@Test

--- a/src/test/java/org/segrada/model/RelationTypeTest.java
+++ b/src/test/java/org/segrada/model/RelationTypeTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,15 +9,15 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class RelationTypeTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -46,37 +46,37 @@ public class RelationTypeTest {
 		relationType.setDescription("Description");
 		relationType.setDescriptionMarkup("default");
 		Set<ConstraintViolation<RelationType>> constraintViolations = validator.validate(relationType);
-		assertTrue("Relation Type not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Relation Type not valid");
 	}
 
 	@Test
 	public void testFromTitleEmpty() throws Exception {
 		Set<ConstraintViolation<RelationType>> constraintViolations = validator.validateValue(RelationType.class, "fromTitle", null);
-		assertTrue("fromTitle empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "fromTitle empty");
 	}
 
 	@Test
 	public void testFromTitleTooShort() throws Exception {
 		Set<ConstraintViolation<RelationType>> constraintViolations = validator.validateValue(RelationType.class, "fromTitle", "");
-		assertTrue("fromTitle too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "fromTitle too short");
 	}
 
 	@Test
 	public void testToTitleEmpty() throws Exception {
 		Set<ConstraintViolation<RelationType>> constraintViolations = validator.validateValue(RelationType.class, "toTitle", null);
-		assertTrue("toTitle empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "toTitle empty");
 	}
 
 	@Test
 	public void testToTitleTooShort() throws Exception {
 		Set<ConstraintViolation<RelationType>> constraintViolations = validator.validateValue(RelationType.class, "toTitle", "");
-		assertTrue("toTitle too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "toTitle too short");
 	}
 
 	@Test
 	public void testDescriptionEmpty() throws Exception {
 		Set<ConstraintViolation<RelationType>> constraintViolations = validator.validateValue(RelationType.class, "description", null);
-		assertTrue("Description empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Description empty");
 	}
 
 	/*@Test
@@ -88,6 +88,6 @@ public class RelationTypeTest {
 	@Test
 	public void testDescriptionMarkupEmpty() throws Exception {
 		Set<ConstraintViolation<RelationType>> constraintViolations = validator.validateValue(RelationType.class, "descriptionMarkup", null);
-		assertTrue("Description markup empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Description markup empty");
 	}
 }

--- a/src/test/java/org/segrada/model/SavedQueryTest.java
+++ b/src/test/java/org/segrada/model/SavedQueryTest.java
@@ -2,8 +2,8 @@ package org.segrada.model;
 
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -11,13 +11,13 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class SavedQueryTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -36,31 +36,31 @@ public class SavedQueryTest {
 		savedQuery.setDescription("Description");
 		savedQuery.setData("Data");
 		Set<ConstraintViolation<SavedQuery>> constraintViolations = validator.validate(savedQuery);
-		assertTrue("Node not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Node not valid");
 	}
 
 	@Test
 	public void testTypeEmpty() throws Exception {
 		Set<ConstraintViolation<SavedQuery>> constraintViolations = validator.validateValue(SavedQuery.class, "type", null);
-		assertTrue("Type empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Type empty");
 	}
 
 	@Test
 	public void testTitleEmpty() throws Exception {
 		Set<ConstraintViolation<SavedQuery>> constraintViolations = validator.validateValue(SavedQuery.class, "title", null);
-		assertTrue("Title empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title empty");
 	}
 
 	@Test
 	public void testDescriptionEmpty() throws Exception {
 		Set<ConstraintViolation<SavedQuery>> constraintViolations = validator.validateValue(SavedQuery.class, "description", null);
-		assertTrue("Description empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Description empty");
 	}
 
 	@Test
 	public void testDataEmpty() throws Exception {
 		Set<ConstraintViolation<SavedQuery>> constraintViolations = validator.validateValue(SavedQuery.class, "data", null);
-		assertTrue("Data empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Data empty");
 	}
 
 	@Test

--- a/src/test/java/org/segrada/model/SourceReferenceTest.java
+++ b/src/test/java/org/segrada/model/SourceReferenceTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,14 +9,14 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class SourceReferenceTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -40,18 +40,18 @@ public class SourceReferenceTest {
 		sourceReference.setSource(new Source());
 		sourceReference.setReference(new Node());
 		Set<ConstraintViolation<SourceReference>> constraintViolations = validator.validate(sourceReference);
-		assertTrue("Source reference not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Source reference not valid");
 	}
 
 	@Test
 	public void testSourceEmpty() throws Exception {
 		Set<ConstraintViolation<SourceReference>> constraintViolations = validator.validateValue(SourceReference.class, "source", null);
-		assertTrue("Source empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Source empty");
 	}
 
 	@Test
 	public void testReferenceEmpty() throws Exception {
 		Set<ConstraintViolation<SourceReference>> constraintViolations = validator.validateValue(SourceReference.class, "reference", null);
-		assertTrue("Reference empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Reference empty");
 	}
 }

--- a/src/test/java/org/segrada/model/SourceTest.java
+++ b/src/test/java/org/segrada/model/SourceTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,15 +9,15 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class SourceTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -50,30 +50,30 @@ public class SourceTest {
 		source.setShortTitle("Example title");
 		source.setShortRef("ex");
 		Set<ConstraintViolation<Source>> constraintViolations = validator.validate(source);
-		assertTrue("Source not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Source not valid");
 	}
 
 	@Test
 	public void testTitleEmpty() throws Exception {
 		Set<ConstraintViolation<Source>> constraintViolations = validator.validateValue(Source.class, "shortTitle", null);
-		assertTrue("Short Title empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Short Title empty");
 	}
 
 	@Test
 	public void testTitleTooShort() throws Exception {
 		Set<ConstraintViolation<Source>> constraintViolations = validator.validateValue(Source.class, "shortTitle", "");
-		assertTrue("Short Title too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Short Title too short");
 	}
 
 	@Test
 	public void testShortRefEmpty() throws Exception {
 		Set<ConstraintViolation<Source>> constraintViolations = validator.validateValue(Source.class, "shortRef", null);
-		assertTrue("Short Ref empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Short Ref empty");
 	}
 
 	@Test
 	public void testShortRefTooShort() throws Exception {
 		Set<ConstraintViolation<Source>> constraintViolations = validator.validateValue(Source.class, "shortRef", "");
-		assertTrue("Short Ref too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Short Ref too short");
 	}
 }

--- a/src/test/java/org/segrada/model/TagTest.java
+++ b/src/test/java/org/segrada/model/TagTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,14 +9,14 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class TagTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -39,19 +39,19 @@ public class TagTest {
 		final Tag tag = new Tag();
 		tag.setTitle("Example title");
 		Set<ConstraintViolation<Tag>> constraintViolations = validator.validate(tag);
-		assertTrue("Tag not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "Tag not valid");
 	}
 
 	@Test
 	public void testTitleEmpty() throws Exception {
 		Set<ConstraintViolation<Tag>> constraintViolations = validator.validateValue(Tag.class, "title", null);
-		assertTrue("Title empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title empty");
 	}
 
 	@Test
 	public void testTitleTooShort() throws Exception {
 		Set<ConstraintViolation<Tag>> constraintViolations = validator.validateValue(Tag.class, "title", "");
-		assertTrue("Title too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title too short");
 	}
 
 }

--- a/src/test/java/org/segrada/model/UserGroupTest.java
+++ b/src/test/java/org/segrada/model/UserGroupTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,13 +9,13 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class UserGroupTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -41,19 +41,19 @@ public class UserGroupTest {
 		userGroup.setDescription("description");
 		userGroup.setSpecial("ADMIN");
 		Set<ConstraintViolation<UserGroup>> constraintViolations = validator.validate(userGroup);
-		assertTrue("UserGroup not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "UserGroup not valid");
 	}
 
 	@Test
 	public void testTitleEmpty() throws Exception {
 		Set<ConstraintViolation<UserGroup>> constraintViolations = validator.validateValue(UserGroup.class, "title", null);
-		assertTrue("Title empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title empty");
 	}
 
 	@Test
 	public void testTitleTooShort() throws Exception {
 		Set<ConstraintViolation<UserGroup>> constraintViolations = validator.validateValue(UserGroup.class, "title", "");
-		assertTrue("Title too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Title too short");
 	}
 
 

--- a/src/test/java/org/segrada/model/UserTest.java
+++ b/src/test/java/org/segrada/model/UserTest.java
@@ -1,7 +1,7 @@
 package org.segrada.model;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,13 +9,13 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 
 public class UserTest {
 	private static Validator validator;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -36,25 +36,25 @@ public class UserTest {
 		user.setPassword("supersecretpassword");
 		user.setGroup(userGroup);
 		Set<ConstraintViolation<User>> constraintViolations = validator.validate(user);
-		assertTrue("User not valid", constraintViolations.size() == 0);
+		assertTrue(constraintViolations.size() == 0, "User not valid");
 	}
 
 	@Test
 	public void testLoginEmpty() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "login", null);
-		assertTrue("Login empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Login empty");
 	}
 
 	@Test
 	public void testLoginTooShort() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "login", "abc");
-		assertTrue("Login too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Login too short");
 	}
 
 	@Test
 	public void testLoginTooLong() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "login", "THISISAVERYLONGLOGINTOOLONG");
-		assertTrue("Login too long", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Login too long");
 	}
 
 	/*@Test
@@ -66,43 +66,43 @@ public class UserTest {
 	@Test
 	public void testPasswordEmpty() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "password", null);
-		assertTrue("Password empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Password empty");
 	}
 
 	@Test
 	public void testPasswordTooShort() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "password", "abcd");
-		assertTrue("Password too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Password too short");
 	}
 
 	@Test
 	public void testPasswordTooLong() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "password", "THISISAVERYLONGPASSWORDJUSTTOOLONGTHISISAVERYLONGPASSWORDJUSTTOOLONGTHISISAVERYLONGPASSWORDJUSTTOOLONGTHISISAVERYLONGPASSWORDJUSTTOOLONGTHISISAVERYLONGPASSWORDJUSTTOOLONGTHISISAVERYLONGPASSWORDJUSTTOOLONGTHISISAVERYLONGPASSWORDJUSTTOOLONGTHISISAVERYLONGPASSWORDJUSTTOOLONGTHISISAVERYLONGPASSWORDJUSTTOOLONG");
-		assertTrue("Password too long", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Password too long");
 	}
 
 	@Test
 	public void testNameEmpty() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "name", null);
-		assertTrue("Name empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Name empty");
 	}
 
 	@Test
 	public void testNameTooShort() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "name", "a");
-		assertTrue("Name too short", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Name too short");
 	}
 
 	@Test
 	public void testNameTooLong() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "name", "This name is too long. This name is too long. This name is too long. This name is too long.");
-		assertTrue("Name too long", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Name too long");
 	}
 
 	@Test
 	public void testEmptyGroup() throws Exception {
 		Set<ConstraintViolation<User>> constraintViolations = validator.validateValue(User.class, "group", null);
-		assertTrue("Group empty", constraintViolations.size() == 1);
+		assertTrue(constraintViolations.size() == 1, "Group empty");
 	}
 
 	@Test

--- a/src/test/java/org/segrada/model/base/AbstractAnnotatedModelTest.java
+++ b/src/test/java/org/segrada/model/base/AbstractAnnotatedModelTest.java
@@ -1,6 +1,6 @@
 package org.segrada.model.base;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Comment;
 import org.segrada.model.File;
 import org.segrada.model.SourceReference;
@@ -12,7 +12,7 @@ import org.segrada.model.prototype.ISourceReference;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractAnnotatedModelTest {
 

--- a/src/test/java/org/segrada/model/base/AbstractColoredModelTest.java
+++ b/src/test/java/org/segrada/model/base/AbstractColoredModelTest.java
@@ -1,8 +1,8 @@
 package org.segrada.model.base;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractColoredModelTest {
 	@Test

--- a/src/test/java/org/segrada/model/base/AbstractCoreModelTest.java
+++ b/src/test/java/org/segrada/model/base/AbstractCoreModelTest.java
@@ -1,13 +1,13 @@
 package org.segrada.model.base;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.*;
 import org.segrada.model.prototype.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractCoreModelTest {
 

--- a/src/test/java/org/segrada/model/base/AbstractSegradaEntityTest.java
+++ b/src/test/java/org/segrada/model/base/AbstractSegradaEntityTest.java
@@ -1,9 +1,9 @@
 package org.segrada.model.base;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.User;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractSegradaEntityTest {
 	@Test
@@ -100,14 +100,14 @@ public class AbstractSegradaEntityTest {
 
 		entity.setId("#12345:45678");
 
-		assertEquals("Id to Uid conversion failed", "12345-45678", entity.getUid());
+		assertEquals("12345-45678", entity.getUid(), "Id to Uid conversion failed");
 	}
 
 	@Test
 	public void testConvertOrientIdToUid() throws Exception {
 		assertNull(AbstractSegradaEntity.convertOrientIdToUid(null));
 		assertNull(AbstractSegradaEntity.convertOrientIdToUid(""));
-		assertEquals("Id to Uid conversion failed", "12345-45678", AbstractSegradaEntity.convertOrientIdToUid("#12345:45678"));
+		assertEquals("12345-45678", AbstractSegradaEntity.convertOrientIdToUid("#12345:45678"), "Id to Uid conversion failed");
 		assertNull(AbstractSegradaEntity.convertOrientIdToUid("xxx"));
 		assertNull(AbstractSegradaEntity.convertOrientIdToUid("123-123"));
 	}
@@ -116,7 +116,7 @@ public class AbstractSegradaEntityTest {
 	public void testConvertUidToOrientId() throws Exception {
 		assertNull(AbstractSegradaEntity.convertUidToOrientId(null));
 		assertNull(AbstractSegradaEntity.convertUidToOrientId(""));
-		assertEquals("Uid to id conversion failed", "#12345:45678", AbstractSegradaEntity.convertUidToOrientId("12345-45678"));
+		assertEquals("#12345:45678", AbstractSegradaEntity.convertUidToOrientId("12345-45678"), "Uid to id conversion failed");
 		assertNull(AbstractSegradaEntity.convertUidToOrientId("xxx"));
 		assertNull(AbstractSegradaEntity.convertUidToOrientId("#123:123"));
 	}

--- a/src/test/java/org/segrada/model/util/FuzzyFlagTest.java
+++ b/src/test/java/org/segrada/model/util/FuzzyFlagTest.java
@@ -1,11 +1,11 @@
 package org.segrada.model.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FuzzyFlagTest {
 

--- a/src/test/java/org/segrada/rendering/markup/DefaultMarkupFilterTest.java
+++ b/src/test/java/org/segrada/rendering/markup/DefaultMarkupFilterTest.java
@@ -1,12 +1,12 @@
 package org.segrada.rendering.markup;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.segrada.rendering.markup.DefaultMarkupFilter;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DefaultMarkupFilterTest {
 	@Test
@@ -14,19 +14,19 @@ public class DefaultMarkupFilterTest {
 		DefaultMarkupFilter filter = new DefaultMarkupFilter();
 
 		String test1 = "This is a text string";
-		assertEquals("Test 1 failed", "This is a text string", filter.toHTML(test1));
+		assertEquals("This is a text string", filter.toHTML(test1), "Test 1 failed");
 
 		String test2 = "This is a text string\nNext line";
-		assertEquals("Test 2 failed", "This is a text string<br/>\nNext line", filter.toHTML(test2));
+		assertEquals("This is a text string<br/>\nNext line", filter.toHTML(test2), "Test 2 failed");
 
 		String test3 = "This is a text string\rNext line";
-		assertEquals("Test 3 failed", "This is a text string<br/>\nNext line", filter.toHTML(test3));
+		assertEquals("This is a text string<br/>\nNext line", filter.toHTML(test3), "Test 3 failed");
 
 		String test4 = "This is a text string\r\nNext line";
-		assertEquals("Test 4 failed", "This is a text string<br/>\nNext line", filter.toHTML(test4));
+		assertEquals("This is a text string<br/>\nNext line", filter.toHTML(test4), "Test 4 failed");
 
 		String test5 = "<br>ÄÖÜ@µ";
-		assertEquals("Test 5 failed", "&lt;br&gt;&Auml;&Ouml;&Uuml;@&micro;", filter.toHTML(test5));
+		assertEquals("&lt;br&gt;&Auml;&Ouml;&Uuml;@&micro;", filter.toHTML(test5), "Test 5 failed");
 	}
 
 	@Test
@@ -34,11 +34,11 @@ public class DefaultMarkupFilterTest {
 		DefaultMarkupFilter filter = new DefaultMarkupFilter();
 
 		String test1 = "Normaltext *bold* _emphasised_ ==underline== *not\nbold* _not\nemphasised_ ==no\nunderline== *not\n*yesbold*";
-		assertEquals("Decoration test failed", "Normaltext <strong>bold</strong> <em>emphasised</em> <span style=\"text-decoration:underline\">underline</span> *not<br/>\n" +
+		assertEquals("Normaltext <strong>bold</strong> <em>emphasised</em> <span style=\"text-decoration:underline\">underline</span> *not<br/>\n" +
 				"bold* _not<br/>\n" +
 				"emphasised_ ==no<br/>\n" +
 				"underline== *not<br/>\n" +
-				"<strong>yesbold</strong>", filter.toHTML(test1));
+				"<strong>yesbold</strong>", filter.toHTML(test1), "Decoration test failed");
 	}
 
 	@Test
@@ -46,7 +46,7 @@ public class DefaultMarkupFilterTest {
 		DefaultMarkupFilter filter = new DefaultMarkupFilter();
 
 		String test1 = "[[haebler:rott]] Blahblah [13f:]";
-		assertEquals("Bibliographic annotations test failed", "[[haebler:rott]] Blahblah <span class=\"sg-label sg-info\">13f:</span>", filter.toHTML(test1));
+		assertEquals("[[haebler:rott]] Blahblah <span class=\"sg-label sg-info\">13f:</span>", filter.toHTML(test1), "Bibliographic annotations test failed");
 	}
 
 	@Test
@@ -54,7 +54,7 @@ public class DefaultMarkupFilterTest {
 		DefaultMarkupFilter filter = new DefaultMarkupFilter();
 
 		String test1 = "1 - 2--3. (c)(C)(R)<=><-> <=<- =>->";
-		assertEquals("Entity test failed", "1 &ndash; 2&mdash;3. &copy;&copy;&reg;&hArr;&harr; &lArr;&larr; &rArr;&rarr;", filter.toHTML(test1));
+		assertEquals("1 &ndash; 2&mdash;3. &copy;&copy;&reg;&hArr;&harr; &lArr;&larr; &rArr;&rarr;", filter.toHTML(test1), "Entity test failed");
 	}
 
 	@Test

--- a/src/test/java/org/segrada/rendering/markup/HtmlMarkupFilterTest.java
+++ b/src/test/java/org/segrada/rendering/markup/HtmlMarkupFilterTest.java
@@ -1,9 +1,9 @@
 package org.segrada.rendering.markup;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.segrada.rendering.markup.HtmlMarkupFilter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HtmlMarkupFilterTest {
 	@Test
@@ -11,10 +11,10 @@ public class HtmlMarkupFilterTest {
 		HtmlMarkupFilter filter = new HtmlMarkupFilter();
 
 		String test1 = "This is a text string";
-		assertEquals("Test 1 failed", test1, filter.toHTML(test1));
+		assertEquals(test1, filter.toHTML(test1), "Test 1 failed");
 
 		String test2 = "<h1>This is a text string</h1>";
-		assertEquals("Test 1 failed", test2, filter.toHTML(test2));
+		assertEquals(test2, filter.toHTML(test2), "Test 1 failed");
 
 		//trivial...
 	}

--- a/src/test/java/org/segrada/rendering/markup/MarkupFilterFactoryTest.java
+++ b/src/test/java/org/segrada/rendering/markup/MarkupFilterFactoryTest.java
@@ -1,12 +1,12 @@
 package org.segrada.rendering.markup;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.segrada.rendering.markup.DefaultMarkupFilter;
 import org.segrada.rendering.markup.MarkupFilter;
 import org.segrada.rendering.markup.MarkupFilterFactory;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MarkupFilterFactoryTest {
 

--- a/src/test/java/org/segrada/rendering/markup/MarkupFilterTest.java
+++ b/src/test/java/org/segrada/rendering/markup/MarkupFilterTest.java
@@ -1,9 +1,9 @@
 package org.segrada.rendering.markup;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.segrada.rendering.markup.MarkupFilter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MarkupFilterTest {
 

--- a/src/test/java/org/segrada/rendering/thymeleaf/processor/MarkupProcessorTest.java
+++ b/src/test/java/org/segrada/rendering/thymeleaf/processor/MarkupProcessorTest.java
@@ -1,8 +1,8 @@
 package org.segrada.rendering.thymeleaf.processor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MarkupProcessorTest {
 	@Test

--- a/src/test/java/org/segrada/rendering/thymeleaf/processor/Nl2BrProcessorTest.java
+++ b/src/test/java/org/segrada/rendering/thymeleaf/processor/Nl2BrProcessorTest.java
@@ -1,8 +1,8 @@
 package org.segrada.rendering.thymeleaf.processor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Nl2BrProcessorTest {
 

--- a/src/test/java/org/segrada/rendering/thymeleaf/util/MimeTypeIsRenderableTest.java
+++ b/src/test/java/org/segrada/rendering/thymeleaf/util/MimeTypeIsRenderableTest.java
@@ -1,8 +1,8 @@
 package org.segrada.rendering.thymeleaf.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MimeTypeIsRenderableTest {
 	@Test

--- a/src/test/java/org/segrada/search/SearchHitTest.java
+++ b/src/test/java/org/segrada/search/SearchHitTest.java
@@ -1,6 +1,6 @@
 package org.segrada.search;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.segrada.test.PropertyAsserter.assertBasicGetterSetterBehavior;
 

--- a/src/test/java/org/segrada/search/lucene/LuceneSearchEngineTest.java
+++ b/src/test/java/org/segrada/search/lucene/LuceneSearchEngineTest.java
@@ -1,15 +1,15 @@
 package org.segrada.search.lucene;
 
 import org.apache.lucene.store.RAMDirectory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.search.SearchHit;
 import org.segrada.service.util.PaginationInfo;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LuceneSearchEngineTest {
 	/**
@@ -17,7 +17,7 @@ public class LuceneSearchEngineTest {
 	 */
 	private LuceneSearchEngine searchEngine;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		searchEngine = new LuceneSearchEngine(new RAMDirectory(), new LuceneSegradaAnalyzer());
 	}
@@ -34,7 +34,7 @@ public class LuceneSearchEngineTest {
 						"eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata " +
 						"sanctus est Lorem ipsum dolor sit amet.", new String[]{}, null, null,1.0f);
 
-		assertTrue("Could not save document to index", check);
+		assertTrue(check, "Could not save document to index");
 
 		// search
 		PaginationInfo<SearchHit> searchResult = searchEngine.search("consetetur hello", null);

--- a/src/test/java/org/segrada/service/base/AbstractFullTextServiceTest.java
+++ b/src/test/java/org/segrada/service/base/AbstractFullTextServiceTest.java
@@ -6,9 +6,9 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
 import org.apache.lucene.store.RAMDirectory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Source;
 import org.segrada.model.prototype.ISource;
 import org.segrada.search.SearchEngine;
@@ -26,7 +26,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 import javax.annotation.Nullable;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractFullTextServiceTest {
 	/**
@@ -54,7 +54,7 @@ public class AbstractFullTextServiceTest {
 	 */
 	private boolean methodCalled;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		searchEngine = new LuceneSearchEngine(new RAMDirectory(), new LuceneSegradaAnalyzer());
 
@@ -70,7 +70,7 @@ public class AbstractFullTextServiceTest {
 		service = new MockService(factory, searchEngine);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// clear search indexes
 		searchEngine.clearAllIndexes();

--- a/src/test/java/org/segrada/service/base/AbstractRepositoryServiceTest.java
+++ b/src/test/java/org/segrada/service/base/AbstractRepositoryServiceTest.java
@@ -5,9 +5,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Color;
 import org.segrada.model.prototype.IColor;
 import org.segrada.service.repository.ColorRepository;
@@ -20,7 +20,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractRepositoryServiceTest {
 	/**
@@ -38,7 +38,7 @@ public class AbstractRepositoryServiceTest {
 	 */
 	private MockService service;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -52,7 +52,7 @@ public class AbstractRepositoryServiceTest {
 		service = new MockService(factory);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("truncate class Color")).execute();

--- a/src/test/java/org/segrada/service/binarydata/BinaryDataServiceFileTest.java
+++ b/src/test/java/org/segrada/service/binarydata/BinaryDataServiceFileTest.java
@@ -1,10 +1,10 @@
 package org.segrada.service.binarydata;
 
 import com.google.common.io.Files;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Node;
 import org.segrada.model.base.AbstractSegradaEntity;
 import org.segrada.model.prototype.SegradaEntity;
@@ -18,7 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BinaryDataServiceFileTest {
 	private static String savePath;
@@ -27,7 +27,7 @@ public class BinaryDataServiceFileTest {
 
 	private static File tempPath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		savePath = System.getProperty("java.io.tmpdir") + File.separator + "segradatest";
 
@@ -39,7 +39,7 @@ public class BinaryDataServiceFileTest {
 		tempPath.mkdirs();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownClass() throws Exception {
 		// delete all
 		deleteDirectory(tempPath);
@@ -71,7 +71,7 @@ public class BinaryDataServiceFileTest {
 	 */
 	private BinaryDataServiceFile binaryDataServiceFile;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		binaryDataServiceFile = new BinaryDataServiceFile(new ApplicationSettings() {
 			@Override

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbColorRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbColorRepositoryTest.java
@@ -3,9 +3,9 @@ package org.segrada.service.repository.orientdb;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Color;
 import org.segrada.model.prototype.IColor;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
@@ -13,7 +13,7 @@ import org.segrada.session.Identity;
 import org.segrada.test.OrientDBTestInstance;
 import org.segrada.test.OrientDbTestApplicationSettings;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OrientDbColorRepositoryTest {
 	/**
@@ -31,7 +31,7 @@ public class OrientDbColorRepositoryTest {
 	 */
 	private OrientDbColorRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -45,7 +45,7 @@ public class OrientDbColorRepositoryTest {
 		repository =  factory.produceRepository(OrientDbColorRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("truncate class Color")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbCommentRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbCommentRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Comment;
 import org.segrada.model.prototype.IComment;
 import org.segrada.model.prototype.SegradaEntity;
@@ -17,7 +17,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbCommentRepositoryTest {
 	/**
@@ -35,7 +35,7 @@ public class OrientDbCommentRepositoryTest {
 	 */
 	private OrientDbCommentRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -49,7 +49,7 @@ public class OrientDbCommentRepositoryTest {
 		repository =  factory.produceRepository(OrientDbCommentRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete edge IsCommentOf")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbConfigRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbConfigRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
 import org.segrada.session.Identity;
 import org.segrada.test.OrientDBTestInstance;
@@ -14,7 +14,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbConfigRepositoryTest {
 	/**
@@ -32,7 +32,7 @@ public class OrientDbConfigRepositoryTest {
 	 */
 	private OrientDbConfigRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -46,7 +46,7 @@ public class OrientDbConfigRepositoryTest {
 		repository =  factory.produceRepository(OrientDbConfigRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("truncate class Config")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbFileRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbFileRepositoryTest.java
@@ -5,9 +5,9 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
 import com.tinkerpop.blueprints.impls.orient.OrientEdge;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Comment;
 import org.segrada.model.File;
 import org.segrada.model.prototype.IComment;
@@ -20,7 +20,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbFileRepositoryTest {
 	/**
@@ -38,7 +38,7 @@ public class OrientDbFileRepositoryTest {
 	 */
 	private OrientDbFileRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -52,7 +52,7 @@ public class OrientDbFileRepositoryTest {
 		repository =  factory.produceRepository(OrientDbFileRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete vertex V")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbLocationRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbLocationRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Location;
 import org.segrada.model.prototype.ILocation;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
@@ -17,8 +17,8 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 import java.util.List;
 import java.util.Objects;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrientDbLocationRepositoryTest {
 	/**
@@ -36,7 +36,7 @@ public class OrientDbLocationRepositoryTest {
 	 */
 	private OrientDbLocationRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -50,7 +50,7 @@ public class OrientDbLocationRepositoryTest {
 		repository =  factory.produceRepository(OrientDbLocationRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("truncate class Location")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbNodeRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbNodeRepositoryTest.java
@@ -5,9 +5,9 @@ import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Location;
 import org.segrada.model.Node;
 import org.segrada.model.Period;
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbNodeRepositoryTest {
 	/**
@@ -47,7 +47,7 @@ public class OrientDbNodeRepositoryTest {
 	 */
 	private OrientDbNodeRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -61,7 +61,7 @@ public class OrientDbNodeRepositoryTest {
 		repository =  factory.produceRepository(OrientDbNodeRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete vertex V")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbPeriodRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbPeriodRepositoryTest.java
@@ -5,9 +5,9 @@ import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Period;
 import org.segrada.model.prototype.IPeriod;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
@@ -17,9 +17,9 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrientDbPeriodRepositoryTest {
 
@@ -38,7 +38,7 @@ public class OrientDbPeriodRepositoryTest {
 	 */
 	private OrientDbPeriodRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -52,7 +52,7 @@ public class OrientDbPeriodRepositoryTest {
 		repository =  factory.produceRepository(OrientDbPeriodRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete vertex V")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbPictogramRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbPictogramRepositoryTest.java
@@ -3,9 +3,9 @@ package org.segrada.service.repository.orientdb;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Pictogram;
 import org.segrada.model.prototype.IPictogram;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
@@ -15,7 +15,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OrientDbPictogramRepositoryTest {
 	/**
@@ -33,7 +33,7 @@ public class OrientDbPictogramRepositoryTest {
 	 */
 	private OrientDbPictogramRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -47,7 +47,7 @@ public class OrientDbPictogramRepositoryTest {
 		repository =  factory.produceRepository(OrientDbPictogramRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("truncate class Pictogram")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbRelationRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbRelationRepositoryTest.java
@@ -7,9 +7,9 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
 import org.apache.commons.lang.NotImplementedException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Node;
 import org.segrada.model.Relation;
 import org.segrada.model.RelationType;
@@ -25,7 +25,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbRelationRepositoryTest {
 	/**
@@ -43,7 +43,7 @@ public class OrientDbRelationRepositoryTest {
 	 */
 	private OrientDbRelationRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -57,7 +57,7 @@ public class OrientDbRelationRepositoryTest {
 		repository =  factory.produceRepository(OrientDbRelationRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete vertex V")).execute();
@@ -146,9 +146,9 @@ public class OrientDbRelationRepositoryTest {
 		assertEquals(node2.getIdentity().toString(), relation.getToEntity().getId());
 	}
 
-	@Test(expected = NotImplementedException.class)
+	@Test
 	public void testConvertToDocument() throws Exception {
-		repository.convertToDocument(new Relation());
+		assertThrows(NotImplementedException.class, () -> repository.convertToDocument(new Relation()));
 	}
 
 	@Test

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbRelationTypeRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbRelationTypeRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.RelationType;
 import org.segrada.model.prototype.IRelationType;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
@@ -16,8 +16,8 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrientDbRelationTypeRepositoryTest {
 
@@ -38,7 +38,7 @@ public class OrientDbRelationTypeRepositoryTest {
 	 */
 	private OrientDbRelationTypeRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -52,7 +52,7 @@ public class OrientDbRelationTypeRepositoryTest {
 		repository =  factory.produceRepository(OrientDbRelationTypeRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete vertex RelationType")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbSavedQueryRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbSavedQueryRepositoryTest.java
@@ -3,9 +3,9 @@ package org.segrada.service.repository.orientdb;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.SavedQuery;
 import org.segrada.model.User;
 import org.segrada.model.prototype.ISavedQuery;
@@ -14,7 +14,7 @@ import org.segrada.session.Identity;
 import org.segrada.test.OrientDBTestInstance;
 import org.segrada.test.OrientDbTestApplicationSettings;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbSavedQueryRepositoryTest {
 	/**
@@ -32,7 +32,7 @@ public class OrientDbSavedQueryRepositoryTest {
 	 */
 	private OrientDbSavedQueryRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -46,7 +46,7 @@ public class OrientDbSavedQueryRepositoryTest {
 		repository =  factory.produceRepository(OrientDbSavedQueryRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("truncate class SavedQuery")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbSourceReferenceRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbSourceReferenceRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Comment;
 import org.segrada.model.Period;
 import org.segrada.model.Source;
@@ -27,8 +27,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrientDbSourceReferenceRepositoryTest {
 
@@ -47,7 +47,7 @@ public class OrientDbSourceReferenceRepositoryTest {
 	 */
 	private OrientDbRepositoryFactory factory;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -61,7 +61,7 @@ public class OrientDbSourceReferenceRepositoryTest {
 		repository =  factory.produceRepository(OrientDbSourceReferenceRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete edge E")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbSourceRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbSourceRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Comment;
 import org.segrada.model.Period;
 import org.segrada.model.Source;
@@ -25,7 +25,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbSourceRepositoryTest {
 	/**
@@ -43,7 +43,7 @@ public class OrientDbSourceRepositoryTest {
 	 */
 	private OrientDbSourceRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -57,7 +57,7 @@ public class OrientDbSourceRepositoryTest {
 		repository =  factory.produceRepository(OrientDbSourceRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete vertex V")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbTagRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbTagRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Node;
 import org.segrada.model.Tag;
 import org.segrada.model.prototype.INode;
@@ -20,7 +20,7 @@ import org.segrada.util.Sluggify;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbTagRepositoryTest {
 	/**
@@ -38,7 +38,7 @@ public class OrientDbTagRepositoryTest {
 	 */
 	private OrientDbTagRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		orientDBTestInstance.setUpSchemaIfNeeded();
 
@@ -52,7 +52,7 @@ public class OrientDbTagRepositoryTest {
 		repository =  factory.produceRepository(OrientDbTagRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("delete vertex V")).execute();
@@ -172,7 +172,7 @@ public class OrientDbTagRepositoryTest {
 	@Test
 	public void testCreateNewTagsByTitles() throws Exception {
 		// make sure we have not created any tags yet
-		assertTrue("Repository not empty", repository.count() == 0);
+		assertTrue(repository.count() == 0, "Repository not empty");
 
 		// some tags
 		String[] tags = new String[]{"Tag1", "Tag2", "Tag3"};
@@ -201,7 +201,7 @@ public class OrientDbTagRepositoryTest {
 	@Test
 	public void testFindTagsByTitles() throws Exception {
 		// make sure we have not created any tags yet
-		assertTrue("Repository not empty", repository.count() == 0);
+		assertTrue(repository.count() == 0, "Repository not empty");
 
 		// create some tags
 		for (int i = 1; i <= 10; i++) {
@@ -233,7 +233,7 @@ public class OrientDbTagRepositoryTest {
 	@Test
 	public void testFindTagIdsByTitles() throws Exception {
 		// make sure we have not created any tags yet
-		assertTrue("Repository not empty", repository.count() == 0);
+		assertTrue(repository.count() == 0, "Repository not empty");
 
 		// create some tags
 		String[] ids = new String[10];
@@ -269,7 +269,7 @@ public class OrientDbTagRepositoryTest {
 	@Test
 	public void testFindTagTitlesByIds() throws Exception {
 		// make sure we have not created any tags yet
-		assertTrue("Repository not empty", repository.count() == 0);
+		assertTrue(repository.count() == 0, "Repository not empty");
 
 		// create some tags
 		String[] ids = new String[10];

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbUserGroupRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbUserGroupRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.UserGroup;
 import org.segrada.model.prototype.IUserGroup;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
@@ -17,7 +17,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbUserGroupRepositoryTest {
 	/**
@@ -35,7 +35,7 @@ public class OrientDbUserGroupRepositoryTest {
 	 */
 	private OrientDbUserGroupRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -49,7 +49,7 @@ public class OrientDbUserGroupRepositoryTest {
 		repository =  factory.produceRepository(OrientDbUserGroupRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("truncate class UserGroup")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientDbUserRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientDbUserRepositoryTest.java
@@ -3,9 +3,9 @@ package org.segrada.service.repository.orientdb;
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.User;
 import org.segrada.model.prototype.IUser;
 import org.segrada.model.prototype.IUserGroup;
@@ -17,7 +17,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbUserRepositoryTest {
 	/**
@@ -35,7 +35,7 @@ public class OrientDbUserRepositoryTest {
 	 */
 	private OrientDbUserRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -49,7 +49,7 @@ public class OrientDbUserRepositoryTest {
 		repository =  factory.produceRepository(OrientDbUserRepository.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		factory.getDb().command(new OCommandSQL("truncate class User")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/OrientRememberMeRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/OrientRememberMeRepositoryTest.java
@@ -6,16 +6,16 @@ import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.test.OrientDBTestInstance;
 
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientRememberMeRepositoryTest {
 	/**
@@ -33,7 +33,7 @@ public class OrientRememberMeRepositoryTest {
 	 */
 	private OrientRememberMeRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -45,7 +45,7 @@ public class OrientRememberMeRepositoryTest {
 		repository = new OrientRememberMeRepository(db);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// truncate db
 		db.command(new OCommandSQL("truncate class User")).execute();

--- a/src/test/java/org/segrada/service/repository/orientdb/base/AbstractAnnotatedOrientDbRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/base/AbstractAnnotatedOrientDbRepositoryTest.java
@@ -5,9 +5,9 @@ import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.base.AbstractAnnotatedModel;
 import org.segrada.model.prototype.IComment;
 import org.segrada.model.prototype.IFile;
@@ -22,7 +22,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractAnnotatedOrientDbRepositoryTest {
 	/**
@@ -40,7 +40,7 @@ public class AbstractAnnotatedOrientDbRepositoryTest {
 	 */
 	private MockOrientDbRepository mockOrientDbRepository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -59,7 +59,7 @@ public class AbstractAnnotatedOrientDbRepositoryTest {
 		factory.addRepository(mockOrientDbRepository.getClass(), mockOrientDbRepository);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// close db
 		try {

--- a/src/test/java/org/segrada/service/repository/orientdb/base/AbstractColoredOrientDbRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/base/AbstractColoredOrientDbRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.base.AbstractColoredModel;
 import org.segrada.model.prototype.IPictogram;
 import org.segrada.model.prototype.SegradaColoredEntity;
@@ -15,8 +15,8 @@ import org.segrada.session.Identity;
 import org.segrada.test.OrientDBTestInstance;
 import org.segrada.test.OrientDbTestApplicationSettings;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class AbstractColoredOrientDbRepositoryTest {
 	/**
@@ -29,7 +29,7 @@ public class AbstractColoredOrientDbRepositoryTest {
 	 */
 	private MockOrientDbRepository mockOrientDbRepository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -46,7 +46,7 @@ public class AbstractColoredOrientDbRepositoryTest {
 		mockOrientDbRepository = new MockOrientDbRepository(factory);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// close db
 		try {

--- a/src/test/java/org/segrada/service/repository/orientdb/base/AbstractCoreOrientDbRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/base/AbstractCoreOrientDbRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Location;
 import org.segrada.model.Node;
 import org.segrada.model.Period;
@@ -29,7 +29,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractCoreOrientDbRepositoryTest {
 	/**
@@ -47,7 +47,7 @@ public class AbstractCoreOrientDbRepositoryTest {
 	 */
 	private MockOrientDbRepository mockOrientDbRepository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set up schema if needed
 		orientDBTestInstance.setUpSchemaIfNeeded();
@@ -64,7 +64,7 @@ public class AbstractCoreOrientDbRepositoryTest {
 		mockOrientDbRepository = new MockOrientDbRepository(factory);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// close db
 		try {

--- a/src/test/java/org/segrada/service/repository/orientdb/base/AbstractOrientDbBaseRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/base/AbstractOrientDbBaseRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.base.AbstractSegradaEntity;
 import org.segrada.model.prototype.SegradaEntity;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
@@ -14,7 +14,7 @@ import org.segrada.session.Identity;
 import org.segrada.test.OrientDBTestInstance;
 import org.segrada.test.OrientDbTestApplicationSettings;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractOrientDbBaseRepositoryTest {
 	/**
@@ -27,7 +27,7 @@ public class AbstractOrientDbBaseRepositoryTest {
 	 */
 	private OrientDbRepositoryFactory factory;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// open database
 		ODatabaseDocumentTx db = orientDBTestInstance.getDatabase();

--- a/src/test/java/org/segrada/service/repository/orientdb/base/AbstractOrientDbRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/base/AbstractOrientDbRepositoryTest.java
@@ -5,9 +5,9 @@ import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.base.AbstractSegradaEntity;
 import org.segrada.model.prototype.IMock;
 import org.segrada.service.repository.orientdb.factory.OrientDbRepositoryFactory;
@@ -17,7 +17,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractOrientDbRepositoryTest {
 	/**
@@ -30,7 +30,7 @@ public class AbstractOrientDbRepositoryTest {
 	 */
 	private MockOrientDbRepository mockOrientDbRepository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// open database
 		ODatabaseDocumentTx db = orientDBTestInstance.getDatabase();
@@ -44,7 +44,7 @@ public class AbstractOrientDbRepositoryTest {
 		mockOrientDbRepository = new MockOrientDbRepository(factory);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// close db
 		try {
@@ -310,7 +310,7 @@ public class AbstractOrientDbRepositoryTest {
 	public void testConvertUidToId() throws Exception {
 		assertNull(mockOrientDbRepository.convertUidToId(null));
 		assertNull(mockOrientDbRepository.convertUidToId(""));
-		assertEquals("Id to Uid conversion failed", "#12345:45678", mockOrientDbRepository.convertUidToId("12345-45678"));
+		assertEquals("#12345:45678", mockOrientDbRepository.convertUidToId("12345-45678"), "Id to Uid conversion failed");
 	}
 
 	/**

--- a/src/test/java/org/segrada/service/repository/orientdb/base/AbstractSegradaOrientDbRepositoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/base/AbstractSegradaOrientDbRepositoryTest.java
@@ -4,9 +4,9 @@ import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
 import com.orientechnologies.orient.core.id.ORecordId;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OCommandSQL;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.Node;
 import org.segrada.model.User;
 import org.segrada.model.base.AbstractSegradaEntity;
@@ -19,7 +19,7 @@ import org.segrada.test.OrientDbTestApplicationSettings;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractSegradaOrientDbRepositoryTest {
 	/**
@@ -32,7 +32,7 @@ public class AbstractSegradaOrientDbRepositoryTest {
 	 */
 	private MockOrientDbRepository mockOrientDbRepository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		orientDBTestInstance.setUpSchemaIfNeeded();
 
@@ -49,7 +49,7 @@ public class AbstractSegradaOrientDbRepositoryTest {
 		mockOrientDbRepository = new MockOrientDbRepository(factory);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		// close db
 		try {

--- a/src/test/java/org/segrada/service/repository/orientdb/factory/OrientDbRepositoryFactoryTest.java
+++ b/src/test/java/org/segrada/service/repository/orientdb/factory/OrientDbRepositoryFactoryTest.java
@@ -1,9 +1,9 @@
 package org.segrada.service.repository.orientdb.factory;
 
 import com.orientechnologies.orient.core.db.document.ODatabaseDocumentTx;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.segrada.service.repository.CommentRepository;
 import org.segrada.service.repository.FileRepository;
 import org.segrada.service.repository.orientdb.OrientDbCommentRepository;
@@ -12,7 +12,7 @@ import org.segrada.session.Identity;
 import org.segrada.test.OrientDBTestInstance;
 import org.segrada.test.OrientDbTestApplicationSettings;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OrientDbRepositoryFactoryTest {
 	/**
@@ -28,7 +28,7 @@ public class OrientDbRepositoryFactoryTest {
 
 	private OrientDbRepositoryFactory factory;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// open database
 		db = orientDBTestInstance.getDatabase();
@@ -36,7 +36,7 @@ public class OrientDbRepositoryFactoryTest {
 		factory = new OrientDbRepositoryFactory(db, applicationSettings, identity);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		factory.getDb().close();
 	}

--- a/src/test/java/org/segrada/service/util/AbstractLazyLoadedObjectTest.java
+++ b/src/test/java/org/segrada/service/util/AbstractLazyLoadedObjectTest.java
@@ -1,17 +1,17 @@
 package org.segrada.service.util;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractLazyLoadedObjectTest {
 	private MockObject mockObject;
 	private MockAbstractLazyLoadedObject mockAbstractLazyLoadedObject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		mockObject = new MockObject();
 		mockAbstractLazyLoadedObject = new MockAbstractLazyLoadedObject(mockObject);

--- a/src/test/java/org/segrada/service/util/PaginationInfoTest.java
+++ b/src/test/java/org/segrada/service/util/PaginationInfoTest.java
@@ -1,8 +1,8 @@
 package org.segrada.service.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PaginationInfoTest {
 

--- a/src/test/java/org/segrada/session/ApplicationSettingsPropertiesTest.java
+++ b/src/test/java/org/segrada/session/ApplicationSettingsPropertiesTest.java
@@ -1,11 +1,11 @@
 package org.segrada.session;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ApplicationSettingsPropertiesTest {
 	/**
@@ -13,7 +13,7 @@ public class ApplicationSettingsPropertiesTest {
 	 */
 	private ApplicationSettingsProperties applicationSettings;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// environmental variables cannot be tested but should be ok
 		applicationSettings = new ApplicationSettingsProperties();

--- a/src/test/java/org/segrada/session/IdentityTest.java
+++ b/src/test/java/org/segrada/session/IdentityTest.java
@@ -1,12 +1,12 @@
 package org.segrada.session;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.segrada.model.User;
 import org.segrada.model.UserGroup;
 import org.segrada.model.prototype.IUser;
 import org.segrada.model.prototype.IUserGroup;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IdentityTest {
 

--- a/src/test/java/org/segrada/test/PropertyAsserter.java
+++ b/src/test/java/org/segrada/test/PropertyAsserter.java
@@ -14,7 +14,7 @@ import java.lang.reflect.Method;
 import java.sql.Timestamp;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test utility class that makes easy work of testing default behavior of getters and setters.
@@ -201,9 +201,9 @@ public enum PropertyAsserter {
 	 */
 	static void assertPropertyResult(String property, Object arg, Class type, Object propertyValue) {
 		if (type.isPrimitive() || type == String.class) {
-			assertEquals(property + " getter/setter failed test", arg, propertyValue);
+			assertEquals(arg, propertyValue, property + " getter/setter failed test");
 		}else {
-			assertSame(property + " getter/setter failed test", arg, propertyValue);
+			assertSame(arg, propertyValue, property + " getter/setter failed test");
 		}
 	}
 

--- a/src/test/java/org/segrada/util/FlexibleDateParserTest.java
+++ b/src/test/java/org/segrada/util/FlexibleDateParserTest.java
@@ -1,10 +1,10 @@
 package org.segrada.util;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class FlexibleDateParserTest {
 	@Test

--- a/src/test/java/org/segrada/util/FuzzyDateRendererTest.java
+++ b/src/test/java/org/segrada/util/FuzzyDateRendererTest.java
@@ -1,8 +1,8 @@
 package org.segrada.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FuzzyDateRendererTest {
 

--- a/src/test/java/org/segrada/util/ImageManipulatorTest.java
+++ b/src/test/java/org/segrada/util/ImageManipulatorTest.java
@@ -1,7 +1,7 @@
 package org.segrada.util;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -10,7 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImageManipulatorTest {
 	/**
@@ -27,7 +27,7 @@ public class ImageManipulatorTest {
 	private static final String mimeJPG = "image/jpeg";
 	private static final String mimeGIF = "image/gif";
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		// load bytes
 		icon_png = resourceToBytes("/img/test_icon.png");

--- a/src/test/java/org/segrada/util/NumberFormatterTest.java
+++ b/src/test/java/org/segrada/util/NumberFormatterTest.java
@@ -1,16 +1,16 @@
 package org.segrada.util;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NumberFormatterTest {
 	private NumberFormatter numberFormatter;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		numberFormatter = new NumberFormatter();
 	}

--- a/src/test/java/org/segrada/util/OrientStringEscapeTest.java
+++ b/src/test/java/org/segrada/util/OrientStringEscapeTest.java
@@ -1,9 +1,9 @@
 package org.segrada.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class OrientStringEscapeTest {
 

--- a/src/test/java/org/segrada/util/PBKDF2WithHmacSHA1PasswordEncoderTest.java
+++ b/src/test/java/org/segrada/util/PBKDF2WithHmacSHA1PasswordEncoderTest.java
@@ -1,9 +1,9 @@
 package org.segrada.util;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PBKDF2WithHmacSHA1PasswordEncoderTest {
 	/**
@@ -16,7 +16,7 @@ public class PBKDF2WithHmacSHA1PasswordEncoderTest {
 	 */
 	private static PasswordEncoder encoder;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setup() {
 		encoder = new PBKDF2WithHmacSHA1PasswordEncoder();
 	}
@@ -37,20 +37,20 @@ public class PBKDF2WithHmacSHA1PasswordEncoderTest {
 		String parts[] = encoded.split(":");
 
 		// make sure that password follows certain patterns
-		assertTrue("Password is not composed of three parts", parts.length == 3);
-		assertTrue("First part of password smaller than 5 letters", parts[0].length() >= 5); // should be at least 10000 today
-		assertTrue("First part of password not a number", parts[0].matches("^[1-9][0-9]*$"));
-		assertTrue("Second part of password smaller than 16 bytes", parts[1].length() == 32);
-		assertTrue("Second part of password not a hex number", parts[1].matches("^[0-9a-f]+$"));
-		assertTrue("Third part of password smaller than 64 bytes", parts[2].length() == 128);
-		assertTrue("Third part of password not a hex number", parts[2].matches("^[0-9a-f]+$"));
+		assertTrue(parts.length == 3, "Password is not composed of three parts");
+		assertTrue(parts[0].length() >= 5, "First part of password smaller than 5 letters"); // should be at least 10000 today
+		assertTrue(parts[0].matches("^[1-9][0-9]*$"), "First part of password not a number");
+		assertTrue(parts[1].length() == 32, "Second part of password smaller than 16 bytes");
+		assertTrue(parts[1].matches("^[0-9a-f]+$"), "Second part of password not a hex number");
+		assertTrue(parts[2].length() == 128, "Third part of password smaller than 64 bytes");
+		assertTrue(parts[2].matches("^[0-9a-f]+$"), "Third part of password not a hex number");
 	}
 
 	@Test
 	public void testMatches() throws Exception {
 		// different sample passwords
-		assertTrue("Password 1000 did not match", encoder.matches(password, "1000:ecebaf7f4ca80b35ad01d9cc9a23d712:e28d2699de28279030c0c2ddb90bf7e32428ccf455123a823ee9e04187ca73e427b12241315048599a56a2d471b85768ecc5250a29b55fb1831b413730d383cb"));
-		assertTrue("Password 10000 did not match", encoder.matches(password, "10000:4a708704ba083f99033cf726f63b88c7:7605720d577d1567659594673596bdb70dadd8286662c4a1bf77e56f304021cb7d91459366ff053d8007f3cfc8a1fdf78d2f633ab14d9f8d9a4ed35546eefa99"));
-		assertTrue("Password 100000 did not match", encoder.matches(password, "100000:de7b326aa219cf55a6868d9ad87df65c:dc2f56de369744eb67ecc33ebb0541223af8d8dfd900e3d3d2150b44213bfe05f704e79c3e314a0e4445af9cd80ae8f09fc80f81e684f5ff99deaf9b72e33bbb"));
+		assertTrue(encoder.matches(password, "1000:ecebaf7f4ca80b35ad01d9cc9a23d712:e28d2699de28279030c0c2ddb90bf7e32428ccf455123a823ee9e04187ca73e427b12241315048599a56a2d471b85768ecc5250a29b55fb1831b413730d383cb"), "Password 1000 did not match");
+		assertTrue(encoder.matches(password, "10000:4a708704ba083f99033cf726f63b88c7:7605720d577d1567659594673596bdb70dadd8286662c4a1bf77e56f304021cb7d91459366ff053d8007f3cfc8a1fdf78d2f633ab14d9f8d9a4ed35546eefa99"), "Password 10000 did not match");
+		assertTrue(encoder.matches(password, "100000:de7b326aa219cf55a6868d9ad87df65c:dc2f56de369744eb67ecc33ebb0541223af8d8dfd900e3d3d2150b44213bfe05f704e79c3e314a0e4445af9cd80ae8f09fc80f81e684f5ff99deaf9b72e33bbb"), "Password 100000 did not match");
 	}
 }

--- a/src/test/java/org/segrada/util/PreconditionsTest.java
+++ b/src/test/java/org/segrada/util/PreconditionsTest.java
@@ -1,9 +1,9 @@
 package org.segrada.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PreconditionsTest {
 
@@ -15,9 +15,9 @@ public class PreconditionsTest {
 		// no exception should be thrown
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void testCheckNotNullFail() throws Exception {
-		assertNull(Preconditions.checkNotNull(null, "test"));
+		assertThrows(NullPointerException.class, () -> Preconditions.checkNotNull(null, "test"));
 		// exception should be thrown
 	}
 }

--- a/src/test/java/org/segrada/util/SluggifyTest.java
+++ b/src/test/java/org/segrada/util/SluggifyTest.java
@@ -1,9 +1,9 @@
 package org.segrada.util;
 
 import net.sf.ehcache.CacheManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SluggifyTest {
 	@Test

--- a/src/test/java/org/segrada/util/TextExtractorTest.java
+++ b/src/test/java/org/segrada/util/TextExtractorTest.java
@@ -1,10 +1,10 @@
 package org.segrada.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TextExtractorTest {
 


### PR DESCRIPTION
This PR upgrades the project to use the modern JUnit Jupiter 5.9.1 instead of the outdated JUnit 4.13.1 in order to make it easier for future contributors to write and maintain unit tests in the project.

**Note:**
While this patch doesn't contain any significant logic, it's already quite large. In an attempt to keep it as easy as possible to review, it was kept minimal and only replaces JUnit 4 constructs with JUnit Jupiter constructs.
With JUnit Jupiter in place, some obvious improvements/cleanups are available, but they will be performed in a followup patch.

This PR includes:
1. pom.xml 
    1. The `junit:junit:4.13.1` dependency was replaced with the modern `org.junit.jupiter:junit-jupiter:5.9.1` dependency
    2. An explicit definition of `maven-surefire-plugin:2.22.2` was introduced instead of the implicit `2.12` version that was not specified in order to be able to execute JUnit Jupiter tests. 
    3. `maven-dependency-plugin`'s `excludeArtifactIds` configuration was updated to exclude `junit-jupiter` instead of `junit`
2. Annotations 
    1. `org.junit.jupiter.api.Test` was used as a drop-in replacement for `org.junit.Test` in the simple case where no arguments were used with the annotation. In the case where the `expected` argument was used this annotation was still used, but the assertions in the test had to be modified, see 3.iii below
    2. `org.junit.jupiter.api.BeforeEach` was used as a drop-in replacement for `org.junit.Before`.
    3. `org.junit.jupiter.api.BeforeAll` was used as a drop-in replacement for `org.junit.BeforeClass`.
    4. `org.junit.jupiter.api.AfterEach` was used as a drop-in replacement for `org.junit.After`.
    5. `org.junit.jupiter.api.AfterAll` was used as a drop-in replacement for `org.junit.AfterClass`. 
    6. In the cases where multiple annotations were replaced in the same class, imports were reorganized to keep their alphabetical order.
3. Assertions 
    1. `org.junit.jupiter.api.Assertions`' methods were used as drop-in replacements for `org.junit.Assert`'s methods with the same name in the simple case where the method was used without the extra message argument. 
    2. In the cases where an `org.junit.Assert` method was used with the extra message argument it was replaced with a call to an `org.junit.jupiter.api.Assertions` method with the same name, and the arguments were rearranged so that the message argument would be last instead of first. 
    3. `org.junit.jupiter.api.Assertions`' `assertThrows` was used to test expected exceptions being thrown where `org.junit.Test` was used with the `expected` argument.